### PR TITLE
Allow "local_size_[xyz]_in" in mesh/task shaders where applicable.

### DIFF
--- a/extensions/nv/GLSL_NV_mesh_shader.txt
+++ b/extensions/nv/GLSL_NV_mesh_shader.txt
@@ -22,8 +22,8 @@ Status
 
 Version
 
-    Last Modified Date:     October 4, 2018
-    NVIDIA Revision:        4
+    Last Modified Date:     October 5, 2018
+    NVIDIA Revision:        5
 
 Dependencies
 
@@ -36,13 +36,15 @@ Dependencies
     This extension is written against the GLSL 4.50.6 Specification
     (Compatibility Profile), dated April 14, 2016.
 
+    This extension interacts with GLSL 4.60 and KHR_vulkan_glsl.
+
     This extension interacts with NV_viewport_array2.
 
     This extension interacts with NV_stereo_view_rendering.
 
     This extension interacts with NVX_multiview_per_view_attributes.
 
-    This extension interacts with ARB_shader_draw_parameters
+    This extension interacts with ARB_shader_draw_parameters.
 
 Overview
 
@@ -1040,6 +1042,27 @@ Modifications to the OpenGL Shading Language Specification, Version 4.50.6
     guarantee to all other shader invocations. ...
 
 
+Interactions with GLSL 4.60 and KHR_vulkan_glsl
+
+    If GLSL 4.60 or KHR_vulkan_glsl is supported, the layout qualifiers
+    "local_size_x_id", "local_size_y_id", and "local_size_z_id" are supported
+    in mesh and task shaders, as in compute shaders.
+
+    In the big layout qualifier table in section 4.4, add:
+
+      Layout Qualifier   | Qualifier | Individual | Block | Block  | Allowed interfaces
+                         | only      | variable   |       | Member |
+      -------------------+-----------+------------+-------+--------+--------------------
+      local_size_x_id =  |           |            |       |        | compute in
+      local_size_y_id =  |     X     |            |       |        | mesh in
+      local_size_z_id =  |           |            |       |        | task in
+                         |           |            |       |        | (SPIR-V generation
+                         |           |            |       |        |  only)
+
+    No changes are required to the spec language describing these layout
+    qualifiers, since the language doesn't specifically reference compute
+    shaders and the mesh/task support should be identical.
+
 Interactions with NV_viewport_array2
 
     If NV_viewport_array2 is not supported, remove gl_ViewportMask[] from the
@@ -1241,6 +1264,10 @@ Issues
       would be necessary to decide if gl_NumWorkGroups should be 5 or 8.
 
 Revision History
+
+    Version 5, October 5, 2018 (pbrown)
+    - Add an interaction with GLSL 4.60 and GL_KHR_vulkan_glsl to allow the
+      use of "local_size_[xyz]_in" where applicable.
 
     Version 4, October 4, 2018 (pbrown)
     - Fix incorrect layout qualifier table entries.  "local_size_[xyz]" is


### PR DESCRIPTION
Add an interaction specifying that the "local_size_[xyz]_in" layout
qualifiers added for compute shaders in GLSL 4.60 and KHR_vulkan_glsl
(SPIR-V compiles only) also work for mesh and task shaders.

@dgkoch @sparmarNV

Note that I am going to be on vacation starting a couple hours from now.  Hopefully Daniel or Sahil can address any feedback issues.