### PR TITLE
Add GL_EXT_shader_realtime_clock extension.

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,3 +59,4 @@ which normatively accepts SPIR-V but does not normatively consume a high-level s
 - [GL_EXT_buffer_reference2](https://github.com/KhronosGroup/GLSL/blob/master/extensions/ext/GLSL_EXT_buffer_reference2.txt)
 - [GL_NV_shader_sm_builtins](https://github.com/KhronosGroup/GLSL/blob/master/extensions/nv/GLSL_NV_shader_sm_builtins.txt)
 - [GL_EXT_demote_to_helper_invocation](https://github.com/KhronosGroup/GLSL/blob/master/extensions/ext/GLSL_EXT_demote_to_helper_invocation.txt)
+- [GL_EXT_shader_realtime_clock](https://github.com/KhronosGroup/GLSL/blob/master/extensions/ext/GL_EXT_shader_realtime_clock.txt)

--- a/extensions/ext/GL_EXT_shader_realtime_clock.txt
+++ b/extensions/ext/GL_EXT_shader_realtime_clock.txt
@@ -1,0 +1,116 @@
+Name
+
+    EXT_shader_realtime_clock
+
+Name Strings
+
+    GL_EXT_shader_realtime_clock
+
+Contact
+
+    Aaron Hagan (aaron.hagan 'at' amd.com)
+
+Contributors
+
+    Aaron Hagan, AMD
+    Daniel Rakos, AMD
+    Timothy Lottes, AMD
+    Graham Sellers, AMD
+
+Status
+
+    Draft
+
+Version
+
+    Last Modified Date: 10/2/2018
+    Revision: 1
+
+Number
+
+    OpenGL Extension #
+
+Dependencies
+
+    This extension is written against Revision 8 of the version 4.40 of the
+    OpenGL Shading Language Specification, dated June 16, 2014.
+
+    This extension builds upon features introduced by the
+    GL_ARB_shader_clock extension.
+
+    This extension interacts with GL_ARB_gpu_shader_int64.
+
+Overview
+
+    This extension exposes a real-time counter which may be used
+    to derive timing information within a shader.
+
+New Procedures and Functions
+
+    None.
+
+New Tokens
+
+    None.
+
+IP Status
+
+    None.
+
+Modifications to the OpenGL Shading Language Specification, Version 4.50
+
+    Including the following line in a shader can be used to control the
+    language features described in this extension:
+
+      #extension GL_EXT_shader_realtime_clock : <behavior>
+
+    where <behavior> is as specified in section 3.3.
+
+    New preprocessor #defines are added to the OpenGL Shading Language:
+
+      #define GL_EXT_shader_realtime_clock     1
+
+Additions to Chapter 8 of the OpenGL Shading Language Specification
+(Built-in Functions)
+
+    Add New Section 8.19, "Timing Functions"
+
+    Syntax:
+
+        uvec2    clockRealtime2x32EXT(void);
+        uint64_t clockRealtimeEXT(void);
+
+    The clockRealtimeEXT() function returns a 64-bit value representing a
+    real-time clock that is globally coherent by all invocations on the GPU.
+    clockRealtime2x32EXT() returns the same value encoded as a two-component
+    vector of 32-bit unsigned integers with the first component containing
+    the 32 least significant bits and the second component containing the 
+    32 most significant bits.
+
+    The units of time are not defined for either of these operations and will
+    wrap after exceeding the maximum value representable in 64 bits. These
+    functions serve as code motion barriers.
+
+Dependencies on GL_ARB_gpu_shader_int64:
+
+    This extension depends on GL_ARB_gpu_shader_int64 for 64-bit integer values.
+    If GL_ARB_gpu_shader_int64 is not supported, remove clockRealtimeEXT() and any
+    reference to the uint64 type.
+
+IP Status
+
+    None.
+
+Issues
+
+1. What is the difference between EXT_shader_realtime_clock and ARB_shader_clock ?
+    
+    RESOLUTION: The main difference between these extensions is locality,
+    EXT_shader_realtime_clock is a clock value that is coherent across all invocations
+    of the GPU, while ARB_shader_clock times are local to single workgroup. 
+
+Revision History
+
+    Rev  Date        Author    Changes
+    ---  ----------  --------  ---------------------------------------------
+      1  10/2/2018   ahagan    Initial revision based on EXT_shader_realtime_clock


### PR DESCRIPTION
GLSL functions for use with the SPV_KHR_shader_clock extension.

Adds the following glsl functions:
        uvec2    clockRealtime2x32EXT(void);
        uint64_t clockRealtimeEXT(void);