### PR TITLE
GL_EXT_null_initializer

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,3 +79,4 @@ which normatively accepts SPIR-V but does not normatively consume a high-level s
 - [GL_EXT_fragment_shader_barycentric](https://github.com/KhronosGroup/GLSL/blob/master/extensions/ext/GLSL_EXT_fragment_shader_barycentric.txt)
 - [GL_EXT_mesh_shader](https://github.com/KhronosGroup/GLSL/blob/master/extensions/ext/GLSL_EXT_mesh_shader.txt)
 - [GL_EXT_opacity_micromap](https://github.com/KhronosGroup/GLSL/blob/master/extensions/ext/GLSL_EXT_opacity_micromap.txt)
+- [GL_EXT_null_initializer](https://github.com/KhronosGroup/GLSL/blob/master/extensions/ext/GL_EXT_null_initializer.txt)

--- a/extensions/ext/GL_EXT_null_initializer.txt
+++ b/extensions/ext/GL_EXT_null_initializer.txt
@@ -89,8 +89,10 @@ Modifications to the OpenGL Shading Language Specification, Version 4.60
     - Composites: each member is recursively defined to be null according to their
       constituent types
 
-   Null initialization can be achieved by using an empty brace expression. Null
-   initializers may only be used to initialize sized-types.
+   It is a compile-time error to null initialize any other type, or to null initialize an
+   unsized array type.
+   
+   Null initialization can be achieved by using an empty brace expression.
 
    For example,
 

--- a/extensions/ext/GL_EXT_null_initializer.txt
+++ b/extensions/ext/GL_EXT_null_initializer.txt
@@ -20,7 +20,7 @@ Contributors
 
 Status
 
-  Draft
+  Complete
 
 Version
 

--- a/extensions/ext/GL_EXT_null_initializer.txt
+++ b/extensions/ext/GL_EXT_null_initializer.txt
@@ -109,7 +109,7 @@ Modifications to the OpenGL Shading Language Specification, Version 4.60
 
   With:
 
-    Variables declared as shared may only have null initializers (see section 4.3.8.1).
+    Variables declared as shared may only have null initializers (see section 4.1.11.1).
     Uninitialized shared variables' contents are undefined at the beginning of shader
     execution. Any data written to shared variables will be visible to other work items
     (executing the same shader) within the same workgroup.

--- a/extensions/ext/GL_EXT_null_initializer.txt
+++ b/extensions/ext/GL_EXT_null_initializer.txt
@@ -1,0 +1,150 @@
+Name
+
+  EXT_null_initializer
+
+Name Strings
+
+  GL_EXT_null_initializer
+
+Contact
+
+  Alan Baker, Google (alanbaker 'at' google.com)
+
+Contributors
+
+  Alan Baker, Google
+  Jeff Bolz, NVIDIA
+  Jason Ekstrand, Intel
+  John Kessenich, Google
+  Daniel Koch, NVIDIA
+
+Status
+
+  Draft
+
+Version
+
+  Last Modified Date:      June 11, 2020
+  Revision:                3
+
+Number
+
+  TBD
+
+Depenendencies
+
+  This extension can be applied to OpenGL GLSL versions 1.40
+  (#version 140) and higher.
+
+  This extension can be applied to OpenGL ES ESSL versions 3.10
+  (#version 310) and higher.
+
+  This extension is written against the OpenGL Shading Language
+  Specification, version 4.60 (revision 7), dated July 10, 2019
+
+  This extension requires GL_KHR_vulkan_glsl
+
+Overview
+
+  This extension adds a null initializer to GLSL and allow shared variables in
+  compute shaders to be null initiailzed. Null initializers are specified using
+  a new syntax of empty braces.
+
+New Procedures and Functions
+
+  None.
+
+New Tokens
+
+  None.
+
+Modifications to GL_KHR_vulkan_glsl
+
+  Add to the "Mapping to SPIR-V" section
+
+  Mapping shared variable initializers:
+
+    Null initializers should be generated as OpConstantNull of the variable's type.
+
+Modifications to the OpenGL Shading Language Specification, Version 4.60
+
+  Including the following line in a shader can be used to control the language
+  features described in this extension:
+
+    #extension GL_EXT_null_initialize_shared_memory : <behavior>
+
+  where <behavior> is as specified in section 3.3.
+
+  New preprocessor #defines are added to the OpenGL Shading Language:
+
+    #define GL_EXT_null_initialize_shared_memory    1
+
+  Add a new section 4.1.11.1 Null Initializers:
+
+    A null initializer is defined for the following types:
+
+    - bool: false
+    - Scalar integers: 0
+    - Scalar floating point: +0.0 (all bits 0)
+    - Composites: each member is recursively defined to be null according to their
+      constituent types
+
+   Null initialization can be achieved by using an empty brace expression. Null
+   initializers may only be used to initialize sized-types.
+
+   For example,
+
+    vec4 x = { };
+
+  In section 4.3.8 Shared Variables:
+
+  Replace the paragraph:
+
+    Variables declared as shared may not have initializers and their contents are
+    undefined at the beginning of shader execution. Any data written to shared
+    variables will be visible to other work items (executing the same shader)
+    within the same workgroup.
+
+  With:
+
+    Variables declared as shared may only have null initializers (see section 4.3.8.1).
+    Uninitialized shared variables' contents are undefined at the beginning of shader
+    execution. Any data written to shared variables will be visible to other work items
+    (executing the same shader) within the same workgroup.
+
+  In section 9 Shading Language Grammar:
+
+  Add the following rule to "initializer: ...":
+
+    initializer :
+      LEFT_BRACE RIGHT_BRACE
+
+Issues
+
+  1. How should the null initializer be specified?
+
+  Discussion: Common idioms include "{ }", "{ 0 }" and default constructors.
+  "{ 0 }" is problematic when considering structs nested inside structs.
+
+  RESOLVED. Only allow empty braces as a null initializer.
+
+  2. To what extent should null initializers be allowed?
+
+  Discussion: The tooling requirements to support null initializers is error
+  prone if they are accepted as a general initializer. Additionally, they are
+  useful beyond just shared variables.
+
+  RESOLVED. Allow null initializers generally.
+
+Revision History
+
+  Revision 1 (Alan Baker)
+    - Internal revision
+
+  Revision 2 (Alan Baker)
+    - Clarify null initializers
+
+  Revision 3 (Alan Baker)
+    - Rename extension from GL_EXT_null_initialize_shared_memory
+    - Allow null initializers generally
+    - Restrict null initializers to sized types

--- a/extensions/ext/GL_EXT_null_initializer.txt
+++ b/extensions/ext/GL_EXT_null_initializer.txt
@@ -71,7 +71,7 @@ Modifications to the OpenGL Shading Language Specification, Version 4.60
   Including the following line in a shader can be used to control the language
   features described in this extension:
 
-    #extension GL_EXT_null_initialize_shared_memory : <behavior>
+    #extension GL_EXT_null_initializer : <behavior>
 
   where <behavior> is as specified in section 3.3.
 

--- a/extensions/ext/GL_EXT_null_initializer.txt
+++ b/extensions/ext/GL_EXT_null_initializer.txt
@@ -77,7 +77,7 @@ Modifications to the OpenGL Shading Language Specification, Version 4.60
 
   New preprocessor #defines are added to the OpenGL Shading Language:
 
-    #define GL_EXT_null_initialize_shared_memory    1
+    #define GL_EXT_null_initializer    1
 
   Add a new section 4.1.11.1 Null Initializers:
 

--- a/extensions/ext/GL_EXT_null_initializer.txt
+++ b/extensions/ext/GL_EXT_null_initializer.txt
@@ -46,7 +46,7 @@ Depenendencies
 
 Overview
 
-  This extension adds a null initializer to GLSL and allow shared variables in
+  This extension adds a null initializer to GLSL and allows shared variables in
   compute shaders to be null initiailzed. Null initializers are specified using
   a new syntax of empty braces.
 

--- a/extensions/ext/GL_EXT_null_initializer.txt
+++ b/extensions/ext/GL_EXT_null_initializer.txt
@@ -47,7 +47,7 @@ Depenendencies
 Overview
 
   This extension adds a null initializer to GLSL and allows shared variables in
-  compute shaders to be null initiailzed. Null initializers are specified using
+  compute shaders to be null initialized. Null initializers are specified using
   a new syntax of empty braces.
 
 New Procedures and Functions

--- a/extensions/ext/GL_EXT_null_initializer.txt
+++ b/extensions/ext/GL_EXT_null_initializer.txt
@@ -24,12 +24,8 @@ Status
 
 Version
 
-  Last Modified Date:      June 11, 2020
-  Revision:                3
-
-Number
-
-  TBD
+  Last Modified Date:      October 25, 2022
+  Revision:                4
 
 Depenendencies
 
@@ -150,3 +146,6 @@ Revision History
     - Rename extension from GL_EXT_null_initialize_shared_memory
     - Allow null initializers generally
     - Restrict null initializers to sized types
+
+  Revision 4 (Alan Baker)
+    - Editorial changes


### PR DESCRIPTION
* Adds a null initializer syntax (empty braces) that can be used to
  initialize variables
* Allows shared variables to use null initializers