### PR TITLE
Added first draft of GLSL_EXT_spirv_intrinsics

### DIFF
--- a/extensions/ext/GLSL_EXT_spirv_intrinsics.txt
+++ b/extensions/ext/GLSL_EXT_spirv_intrinsics.txt
@@ -458,6 +458,7 @@ Additions to Chapter 4 of the OpenGL Shading Language Specification
         spirv_type-parameter:
 
             constant-expression
+            spirv_id constant-expression
 
         spirv_instruction-qualifier-list:
 
@@ -480,6 +481,10 @@ Additions to Chapter 4 of the OpenGL Shading Language Specification
 
         Parameters to this qualifier must be either literal values, or constant
         expressions as defined in section 4.3.3, Constant Expressions.
+        If `spirv_id` is present in front of a parameter, the compiler will
+        always generate constant instruction <id>s for the parameter; if not,
+        it will attempt to resolve it to a literal value, and raise an error
+        if it cannot.
 
         When generating SPIR-V, the compiler will generate type
         instructions for these types in the following manner:
@@ -1033,3 +1038,5 @@ Revision History
                                Updated contributor list.
      8    2023-06-16  thector  Clarified grammar and rules for decorate and
                                execution mode intrinsics.
+     9    2023-06-16  thector  Added `spirv_id` qualifier to type parameter
+                               lists to differentiate literals from <id>s.

--- a/extensions/ext/GLSL_EXT_spirv_intrinsics.txt
+++ b/extensions/ext/GLSL_EXT_spirv_intrinsics.txt
@@ -534,7 +534,7 @@ Additions to Chapter 6 of the OpenGL Shading Language Specification
             An error will be generated if the front-end compiler cannot generate
             a literal 32-bit value.
             Unlike `spirv_by_reference`, `spirv_literal` can only be used on
-            functions defined with `spirv_instruction`, and are invalid on
+            functions defined with `spirv_instruction`, and is invalid on
             user-defined functions.
 
     Add a new section 6.1.3, SPIR-V Instructions

--- a/extensions/ext/GLSL_EXT_spirv_intrinsics.txt
+++ b/extensions/ext/GLSL_EXT_spirv_intrinsics.txt
@@ -552,7 +552,7 @@ Additions to Chapter 6 of the OpenGL Shading Language Specification
         declaration that has a return type and parameters matching those of the
         desired instruction.
         If any parameters of the instruction should be passed by pointer
-        rather than by object, those parameters should additionally be
+        rather than by object, those parameters must additionally be
         decorated with `spirv_by_reference`.
         If any parameters of the instruction are literals, those parameters
         should additionally be decorated with `spirv_literal`.

--- a/extensions/ext/GLSL_EXT_spirv_intrinsics.txt
+++ b/extensions/ext/GLSL_EXT_spirv_intrinsics.txt
@@ -226,7 +226,7 @@ Additions to Chapter 3 of the OpenGL Shading Language Specification
         SPIR-V intrinsics used by a shader may be defined by extensions, or
         guarded by capabilities.
         Each intrinsic can take a list of extensions and capabilities which
-        must be enabled in the generated spir-v in order to use that
+        must be enabled in the generated SPIR-V in order to use that
         intrinsic.
     
         spirv-requirements-list:

--- a/extensions/ext/GLSL_EXT_spirv_intrinsics.txt
+++ b/extensions/ext/GLSL_EXT_spirv_intrinsics.txt
@@ -458,7 +458,6 @@ Additions to Chapter 4 of the OpenGL Shading Language Specification
         spirv_type-parameter:
 
             constant-expression
-            literal
 
         spirv_instruction-qualifier-list:
 

--- a/extensions/ext/GLSL_EXT_spirv_intrinsics.txt
+++ b/extensions/ext/GLSL_EXT_spirv_intrinsics.txt
@@ -269,31 +269,30 @@ Additions to Chapter 3 of the OpenGL Shading Language Specification
         spirv_execution_mode-qualifier:
         
             `spirv_execution_mode` ( integer-constant-expression )
-            `spirv_execution_mode` ( integer-constant-expression, spirv_execution_mode-parameter-list )
+            `spirv_execution_mode` ( integer-constant-expression, spirv_literal-parameter-list )
             `spirv_execution_mode` ( spirv-requirements-list, integer-constant-expression )
-            `spirv_execution_mode` ( spirv-requirements-list, integer-constant-expression, spirv_execution_mode-parameter-list )
+            `spirv_execution_mode` ( spirv-requirements-list, integer-constant-expression, spirv_literal-parameter-list )
             
             `spirv_execution_mode_id` ( integer-constant-expression )
-            `spirv_execution_mode_id` ( integer-constant-expression, spirv_execution_mode_id-parameter-list )
+            `spirv_execution_mode_id` ( integer-constant-expression, spirv_expression-parameter-list )
             `spirv_execution_mode_id` ( spirv-requirements-list, integer-constant-expression )
-            `spirv_execution_mode_id` ( spirv-requirements-list, integer-constant-expression, spirv_execution_mode_id-parameter-list )
+            `spirv_execution_mode_id` ( spirv-requirements-list, integer-constant-expression, spirv_expression-parameter-list )
 
-        spirv_execution_mode-parameter-list:
+        spirv_literal-parameter-list:
 
-            spirv_execution_mode-parameter
-            spirv_execution_mode-parameter , spirv_execution_mode-parameter-list
+            spirv_literal-parameter
+            spirv_literal-parameter , spirv_literal-parameter-list
 
-        spirv_execution_mode-parameter:
+        spirv_literal-parameter:
 
             floating-constant
             integer-constant
             bool-constant
-            literal-string
 
-        spirv_execution_mode_id-parameter-list:
+        spirv_expression-parameter-list:
 
             constant-expression
-            constant-expression , spirv_execution_mode_id-parameter-list
+            constant-expression , spirv_expression-parameter-list
 
         The `spirv_execution_mode` qualifier declares a SPIR-V execution mode
         used by this shader.
@@ -301,13 +300,18 @@ Additions to Chapter 3 of the OpenGL Shading Language Specification
         SPIR-V code taking the first integer parameter as its `Mode` operand,
         and subsequent operands used as its `Extra Operands`, in the same
         order they are declared.
+        Parameters included in the parameter list of this qualifier must be
+        literal values, otherwise a compiler error is generated.
 
-        The `spirv_execution_mode_id` qualifier is similar to
-        `spirv_execution_mode`, but allows the use of constant expressions
-        rather than only literals, and generates an *OpExecutionModeId*
-        instruction instead.
-        Parameters to this qualifier must be constant expressions as defined
-        in section 4.3.3, Constant Expressions. 
+        The `spirv_execution_mode_id` qualifier declares a SPIR-V execution
+        mode used by this shader with non-literal parameters.
+        An *OpExecutionModeId* instruction will be inserted into the generated
+        SPIR-V code taking the first integer parameter as its `Mode` operand,
+        and subsequent operands used as its `Extra Operands`, in the same
+        order they are declared.
+        Parameters included in the parameter list of this qualifier must be
+        constant expressions as defined in section 4.3.3, Constant
+        Expressions, otherwise a compiler error is generated.
 
         Any extensions or capabilities needed by the execution mode
         must be declared using SPIR-V Requirements Declarations
@@ -380,33 +384,17 @@ Additions to Chapter 4 of the OpenGL Shading Language Specification
 
         spirv_decorate-qualifier:
 
-            `spirv_decorate` ( integer-constant, spirv_decorate-parameter-list )
-            `spirv_decorate` ( spirv-requirements-list , integer-constant, spirv_decorate-parameter-list )
-            `spirv_decorate_id` ( integer-constant, spirv_decorate_id-parameter-list  )
-            `spirv_decorate_id` ( spirv-requirements-list , integer-constant, spirv_decorate_id-parameter-list  )
-            `spirv_decorate_string` ( integer-constant, spirv_decorate_string-parameter-list )
-            `spirv_decorate_string` ( spirv-requirements-list , integer-constant, spirv_decorate_string-parameter-list )
+            `spirv_decorate` ( integer-constant, spirv_literal-parameter-list )
+            `spirv_decorate` ( spirv-requirements-list , integer-constant, spirv_literal-parameter-list )
+            `spirv_decorate_id` ( integer-constant, spirv_expression-parameter-list  )
+            `spirv_decorate_id` ( spirv-requirements-list , integer-constant, spirv_expression-parameter-list  )
+            `spirv_decorate_string` ( integer-constant, spirv_string-parameter-list )
+            `spirv_decorate_string` ( spirv-requirements-list , integer-constant, spirv_string-parameter-list )
 
-        spirv_decorate-parameter-list:
-
-            spirv_decorate-parameter
-            spirv_decorate-parameter , spirv_decorate-parameter-list
-
-        spirv_decorate-parameter:
-
-            floating-constant
-            integer-constant
-            bool-constant
-
-        spirv_decorate_id-parameter-list:
-
-            constant-expression
-            constant-expression , spirv_decorate_id-parameter-list
-
-        spirv_decorate_string-parameter-list:
+        spirv_string-parameter-list:
 
             literal-string
-            literal-string , spirv_decorate_string-parameter-list
+            literal-string , spirv_string-parameter-list
 
         The `spirv_decorate` qualifier inserts an *OpDecorate* or
         *OpMemberDecorate* instruction into the generated SPIR-V code,
@@ -414,18 +402,15 @@ Additions to Chapter 4 of the OpenGL Shading Language Specification
         and further parameters as `Extra Operands`.
         If the `spirv_decorate` qualifier is applied to a struct member,
         *OpMemberDecorate* is inserted, otherwise *OpDecorate* is.
-        Integer and floating point values used must be expressible in a
-        32-bit range.
-        An error will be generated if the front-end compiler detects a
-        value outside of the 32-bit range.
-
+        Parameters included in the parameter list of this qualifier must be
+        literal values, otherwise a compiler error is generated.
+        
         The `spirv_decorate_id` qualifier inserts an *OpDecorateId*
         instruction into the generated SPIR-V code, taking the first
         integer parameter as its `Decoration` operand, and further
         parameters as `Extra Operands`.
-        Parameters to this qualifier must be a constant expression that
-        doesn't involve a specialization constant, as defined in section
-        4.3.3, Constant Expressions.
+        There are no restrictions on parameters that can be included in the
+        parameter list of this qualifier.
 
         The `spirv_decorate_string` qualifier inserts an *OpDecorateString*
         or *OpMemberDecorateString* instruction into the generated SPIR-V
@@ -435,6 +420,8 @@ Additions to Chapter 4 of the OpenGL Shading Language Specification
         If the `spirv_decorate_string` qualifier is applied to a struct
         member, *OpMemberDecorateString* is inserted, otherwise
         *OpDecorateString* is.
+        Parameters included in the parameter list of this qualifier must be
+        literal strings, otherwise a compiler error is generated.
 
         Any extensions or capabilities needed by the decoration must be
         declared using SPIR-V Requirements Declarations (see section 3.9).
@@ -644,20 +631,20 @@ Additions to Chapter 9 of the OpenGL Shading Language Specification
         spirv_execution_mode-qualifier:
 
             SPIRV_EXECUTION_MODE LEFT_PAREN INTCONSTANT RIGHT_PAREN
-            SPIRV_EXECUTION_MODE LEFT_PAREN INTCONSTANT COMMA spirv_execution_mode-parameter-list RIGHT_PAREN
+            SPIRV_EXECUTION_MODE LEFT_PAREN INTCONSTANT COMMA spirv_literal-parameter-list RIGHT_PAREN
             SPIRV_EXECUTION_MODE LEFT_PAREN spirv-requirements-list COMMA INTCONSTANT  RIGHT_PAREN
-            SPIRV_EXECUTION_MODE LEFT_PAREN spirv-requirements-list COMMA INTCONSTANT COMMA spirv_execution_mode-parameter-list RIGHT_PAREN
+            SPIRV_EXECUTION_MODE LEFT_PAREN spirv-requirements-list COMMA INTCONSTANT COMMA spirv_literal-parameter-list RIGHT_PAREN
             SPIRV_EXECUTION_MODE_ID LEFT_PAREN INTCONSTANT RIGHT_PAREN
-            SPIRV_EXECUTION_MODE_ID LEFT_PAREN INTCONSTANT COMMA spirv_execution_mode_id-parameter-list RIGHT_PAREN
+            SPIRV_EXECUTION_MODE_ID LEFT_PAREN INTCONSTANT COMMA spirv_expression-parameter-list RIGHT_PAREN
             SPIRV_EXECUTION_MODE_ID LEFT_PAREN INTCONSTANT COMMA spirv-requirements-list RIGHT_PAREN
-            SPIRV_EXECUTION_MODE_ID LEFT_PAREN INTCONSTANT COMMA spirv-requirements-list COMMA spirv_execution_mode_id-parameter-list RIGHT_PAREN
+            SPIRV_EXECUTION_MODE_ID LEFT_PAREN INTCONSTANT COMMA spirv-requirements-list COMMA spirv_expression-parameter-list RIGHT_PAREN
 
-        spirv_execution_mode-parameter-list:
+        spirv_literal-parameter-list:
 
-            spirv_execution_mode-parameter
-            spirv_execution_mode-parameter COMMA spirv_execution_mode-parameter-list
+            spirv_literal-parameter
+            spirv_literal-parameter COMMA spirv_literal-parameter-list
 
-        spirv_execution_mode-parameter:
+        spirv_literal-parameter:
 
             FLOATCONSTANT
             INTCONSTANT
@@ -665,10 +652,10 @@ Additions to Chapter 9 of the OpenGL Shading Language Specification
             BOOLCONSTANT
             STRING_LITERAL
 
-        spirv_execution_mode_id-parameter-list:
+        spirv_expression-parameter-list:
 
             constant-expression
-            constant-expression COMMA spirv_execution_mode_id-parameter-list
+            constant-expression COMMA spirv_expression-parameter-list
 
         spirv_decorate-qualifier:
 
@@ -1006,11 +993,19 @@ Issues
     The main issue spotted so far is any keywords that are applied to a variable
     (e.g. `shadercallcoherent`) in GLSL but are applied to particular
     operations in SPIR-V (e.g. `ShaderCallKHR` scope).
-
     This extension isn't designed as a replacement for language features
     however, so this type of restriction seems fine. The functionality in
-    the example can be achieved directly by adding a new "scope" constant.
+    this example can be achieved directly by adding a new "scope" constant.
 
+    Additionally, type declarations that require other type declarations are
+    not possible to express directly, as GLSL has no type declarations (e.g.
+    `typedef`) and thus can't express an identifier to types.
+    `spirv_type` is a type declaration of sorts, but it has no associated
+    identifier, so can't be referenced by other instances of `spirv_type`.
+    This means any new types with chained types (e.g. pointers) cannot be
+    expressed.
+    If this functionality is desired, it can be added by a future extension.
+    
 Revision History
 
     Rev.    Date      Author   Changes
@@ -1036,3 +1031,5 @@ Revision History
                                Removed broken spirv_literal example.
      7    2021-03-02  thector  Added spirv_literal example.
                                Updated contributor list.
+     8    2023-06-16  thector  Clarified grammar and rules for decorate and
+                               execution mode intrinsics.

--- a/extensions/ext/GLSL_EXT_spirv_intrinsics.txt
+++ b/extensions/ext/GLSL_EXT_spirv_intrinsics.txt
@@ -1,0 +1,1020 @@
+Name
+
+    EXT_spirv_intrinsics
+
+Name Strings
+
+    GL_EXT_spirv_intrinsics
+
+Contact
+
+    Tobias Hector, AMD (tobias.hector 'at' amd.com)
+
+Contributors
+
+    Tobias Hector, AMD
+    Matthaeus Chajdas, AMD
+    Rex Xu, AMD
+    Qun Lin, AMD
+    Nicolai Haehnle, AMD
+    Jason Ekstrand, Intel
+    Christoph Kubisch, NVidia
+    Alan Baker, Google
+    Contributors to the GLSL_EXT_debug_printf extension (for literal string grammar)
+
+Status
+
+    Draft.
+
+Version
+
+    Revision: 7
+    Last Modified Date: 2021-03-02
+
+Dependencies
+
+    This extension is written against version 4.60.7 of the
+    OpenGL Shading Language Specification, dated July 10, 2019.
+
+Overview
+
+    This extension allows shaders to invoke SPIR-V features that have
+    not been integrated into GLSL directly or even understood by the GLSL
+    compiler, via use of new qualifiers for instructions, types, execution
+    modes, decorations, capabilities, and extensions.
+    
+    It does not add the ability to define new shader types, or any language
+    features that don't have a reasonable match between the languages.
+    
+    The intent of this extension is to improve the iteration time when
+    developing a new feature - new functionality can be used in GLSL
+    without having to modify glslang, beyond defining a "header" file.
+
+Modifications to the OpenGL Shading Language Specification, Version 4.60.7
+
+    Including the following line in a shader can be used to control the
+    language features described in this extension:
+
+        #extension GL_EXT_spirv_intrinsics : <behavior>
+
+    where <behavior> is as specified in section 3.3.
+
+    New preprocessor #defines are added to the OpenGL Shading Language:
+
+        #define GL_EXT_spirv_intrinsics         1
+
+Additions to Chapter 3 of the OpenGL Shading Language Specification
+(Basics)
+
+    Modify Section 3.1 Character Set and Phases of Compilation
+
+    Add to the list of supported characters:
+
+        single quote ('), double quote ("), backslash (\)
+
+    Replace the paragraph "There are no character or string data types, so
+    no quoting characters are included" with:
+
+        There are no character or string data types, but literal strings can be
+        used. A literal string is an initial double quote character, followed by
+        a sequence of characters and escape sequences, followed by a final double
+        quote character. An escape sequence is a short sequence of characters
+        contained within a string literal where the first character of the
+        sequence is a backslash. The escape sequences and character they are
+        treated as are:
+
+         - \'   ->  single quote
+         - \"   ->  double quote
+         - \?   ->  question mark
+         - \\   ->  backslash
+         - \a   ->  alert (ASCII 0x07)
+         - \b   ->  backspace (ASCII 0x08)
+         - \f   ->  page break (ASCII 0x0C)
+         - \n   ->  new line (ASCII 0x0A)
+         - \r   ->  carriage return (ASCII 0x0D)
+         - \t   ->  horizontal tab (ASCII 0x09)
+         - \v   ->  vertical tab (ASCII 0x0B)
+         - \xhh ->  'hh' interpreted as a hexadecimal number
+         - \nnn ->  'nnn' interpreted as an octal number
+
+        Octal escape sequences consist of one, two, or three octal digits, and end
+        at the first character that is not an octal digit or at the third octal
+        digit, whichever comes first.
+
+        Hexadecimal escape sequences have one or more hex digits, and end at the
+        first character that is not a hex digit.
+
+        If the octal or hexadecimal value is greater than 127, then the escape
+        sequence has an undefined value.
+
+    Modify Section 3.3, Preprocessor
+    
+    Change the following sentence on page 11 to include the "GL_" prefix,
+    from:
+    
+        By convention, all macro names containing two consecutive
+        underscores (__) are reserved for use by underlying software layers.
+        
+    to:
+        
+        By convention, all macro names containing two consecutive
+        underscores (__) or prefixed with “GL_” (“GL” followed by a single
+        underscore) are reserved for use by underlying software layers.
+
+    Remove the following sentence on page 11:
+    
+        All macro names prefixed with “GL_” (“GL” followed by a single
+        underscore) are also reserved, and defining or undefining such a
+        name results in a compile-time error.
+
+    Add the following to the end of this section:
+
+        Additional compiler macros are available indicating the current shader type.
+
+        When compiling a vertex shader, the following predefined macro is available:
+
+            #define GL_VERTEX_SHADER 1
+
+        When compiling a fragment shader, the following predefined macro is available:
+
+            #define GL_FRAGMENT_SHADER 1
+
+        When compiling a geometry shader, the following predefined macro is available:
+
+            #define GL_GEOMETRY_SHADER 1
+
+        When compiling a tessellation control shader, the following predefined macro is available:
+
+            #define GL_TESSELLATION_CONTROL_SHADER 1
+
+        When compiling a tessellation evaluation shader, the following predefined macro is available:
+
+            #define GL_TESSELLATION_EVALUATION_SHADER 1
+
+    [[If GL_EXT_ray_tracing is supported]]
+        When compiling a ray generation shader, the following predefined macro is available:
+
+            #define GL_RAY_GENERATION_SHADER_EXT 1
+
+        When compiling an intersection shader, the following predefined macro is available:
+
+            #define GL_INTERSECTION_SHADER_EXT 1
+
+        When compiling an any-hit shader, the following predefined macro is available:
+
+            #define GL_ANY_HIT_SHADER_EXT 1
+
+        When compiling a closest hit shader, the following predefined macro is available:
+
+            #define GL_CLOSEST_HIT_SHADER_EXT 1
+
+        When compiling a miss shader, the following predefined macro is available:
+
+            #define GL_MISS_SHADER_EXT 1
+
+        When compiling a callable shader, the following predefined macro is available:
+
+            #define GL_CALLABLE_SHADER_EXT 1
+
+    [[End GL_EXT_ray_tracing]]
+
+    [[If GL_NV_mesh_shader is supported]]
+        When compiling a task shader, the following predefined macro is available:
+
+            #define GL_TASK_SHADER_NV 1
+
+        When compiling a mesh shader, the following predefined macro is available:
+
+            #define GL_MESH_SHADER_NV 1
+
+    [[End GL_NV_mesh_shader]]
+
+    Modify Section 3.6, Keywords
+
+    Add the following keywords:
+
+        spirv_instruction spirv_execution_mode spirv_execution_mode_id
+        spirv_decorate spirv_decorate_id spirv_decorate_string
+        spirv_type spirv_storage_class spirv_by_reference
+        spirv_literal
+        
+    Modify Section 3.7, Identifiers:
+    
+    Remove the following paragraph on page 21:
+
+        Identifiers starting with “gl_” are reserved, and in general, may
+        not be declared in a shader; this results in a compile-time error.
+        However, as noted in the specification, there are some cases where
+        previously declared variables can be redeclared, and predeclared
+        “gl_” names are allowed to be redeclared in a shader only for these
+        specific purposes.
+        
+    Add a new paragraph at the end of section 3.7:
+
+        By convention, all identifiers prefixed with “gl_” are reserved for
+        use by underlying software layers.
+        Defining such an identifier in a shader does not itself result in
+        an error, but may result in unintended behaviors that stem from
+        having multiple definitions of the same name.
+        However, as noted in the specification, there are some cases where
+        previously declared variables can be redeclared, and predeclared
+        “gl_” names are allowed to be redeclared in a shader for these
+        specific purposes with defined behavior.
+
+    Add a new section 3.9, SPIR-V Requirements
+    
+        SPIR-V intrinsics used by a shader may be defined by extensions, or
+        guarded by capabilities.
+        Each intrinsic can take a list of extensions and capabilities which
+        must be enabled in the generated spir-v in order to use that
+        intrinsic.
+    
+        spirv-requirements-list:
+            spirv-requirements-parameter
+            spirv-requirements-parameter , spirv-requirements-list
+        
+        spirv-requirements-parameter:
+            capabilities = [ spirv-capability-list ]
+            extensions = [ spirv-extension-list ]
+
+        spirv-capability-list:
+
+            integer-constant
+            integer-constant , spirv-capability-list
+
+        spirv-extension-list:
+
+            literal-string
+            literal-string , spirv-extension-list
+
+        The `extensions` qualifier declares a list of SPIR-V extensions
+        that are required to use this instruction.
+        An *OpExtension* instruction will be inserted into the generated
+        SPIR-V code for each declared extension with the string parameter
+        as its `Name` operand, if it is not already present.
+
+        The `capabilities` qualifier declares a list of SPIR-V capabilities
+        that are required to use this instruction.
+        An *OpCapability* instruction will be inserted into the generated
+        SPIR-V code for each declared capability with the integer parameter
+        as its `Capability` operand, if it is not already present.
+
+    Add a new section 3.9, SPIR-V Execution Mode Declarations
+
+        The `spirv_execution_mode` and `spirv_execution_mode_id` qualifiers
+        can be used to define specific execution modes used by the
+        generated SPIR-V.
+        These qualifiers must be declared at global scope.
+
+        spirv_execution_mode-qualifier:
+        
+            `spirv_execution_mode` ( integer-constant-expression )
+            `spirv_execution_mode` ( integer-constant-expression, spirv_execution_mode-parameter-list )
+            `spirv_execution_mode` ( spirv-requirements-list, integer-constant-expression )
+            `spirv_execution_mode` ( spirv-requirements-list, integer-constant-expression, spirv_execution_mode-parameter-list )
+            
+            `spirv_execution_mode_id` ( integer-constant-expression )
+            `spirv_execution_mode_id` ( integer-constant-expression, spirv_execution_mode_id-parameter-list )
+            `spirv_execution_mode_id` ( spirv-requirements-list, integer-constant-expression )
+            `spirv_execution_mode_id` ( spirv-requirements-list, integer-constant-expression, spirv_execution_mode_id-parameter-list )
+
+        spirv_execution_mode-parameter-list:
+
+            spirv_execution_mode-parameter
+            spirv_execution_mode-parameter , spirv_execution_mode-parameter-list
+
+        spirv_execution_mode-parameter:
+
+            floating-constant
+            integer-constant
+            bool-constant
+            literal-string
+
+        spirv_execution_mode_id-parameter-list:
+
+            constant-expression
+            constant-expression , spirv_execution_mode_id-parameter-list
+
+        The `spirv_execution_mode` qualifier declares a SPIR-V execution mode
+        used by this shader.
+        An *OpExecutionMode* instruction will be inserted into the generated
+        SPIR-V code taking the first integer parameter as its `Mode` operand,
+        and subsequent operands used as its `Extra Operands`, in the same
+        order they are declared.
+
+        The `spirv_execution_mode_id` qualifier is similar to
+        `spirv_execution_mode`, but allows the use of constant expressions
+        rather than only literals, and generates an *OpExecutionModeId*
+        instruction instead.
+        Parameters to this qualifier must be constant expressions as defined
+        in section 4.3.3, Constant Expressions. 
+
+        Any extensions or capabilities needed by the execution mode
+        must be declared using SPIR-V Requirements Declarations
+        (see section 3.9).
+
+Additions to Chapter 4 of the OpenGL Shading Language Specification
+(Variables and Types)
+
+    Modify section 4.3, editing the first table in this section to include
+    the following entry:
+
+        +-----------------------+----------------------------------------+
+        | Storage Qualifier     | Meaning                                |
+        +-----------------------+----------------------------------------+
+        | spirv_storage_class() | Storage class defined for SPIR-V only. |
+        +-----------------------+----------------------------------------+
+
+    Modify section 4.3.9. Interface Blocks, adding the following to the
+    definition of interface-qualifier:
+
+        interface-qualifier:
+            `spirv_storage_class` ( integer-constant-expression )
+            `spirv_storage_class` ( spirv-requirements-list, integer-constant-expression )
+
+    Add new subsection 4.3.10. SPIR-V Storage Classes
+
+        SPIR-V storage classes not known to or exposed by the GLSL compiler
+        can be applied to variables declared at global scope by use of the
+        `spirv_storage_class` qualifier.
+
+        This functionality is only available when generating SPIR-V.
+
+        The `spirv_storage_class` qualifier can only be used on variable
+        declarations at global scope.
+
+        spirv_storage_class-qualifier:
+
+            `spirv_storage_class` ( integer-constant-expression )
+            `spirv_storage_class` ( spirv-requirements-list, integer-constant-expression )
+
+        The `spirv_storage_class` modifies the *StorageClass* operand of
+        declared variables to be the storage class defined for the
+        *StorageClass* enumeration equal to the integer value provided.
+
+        Any extensions or capabilities needed by the storage class must be
+        declared using SPIR-V Requirements Declarations (see section 3.9).
+
+    Add a new section 4.14. SPIR-V Decorations
+
+        SPIR-V decorations not known to or exposed by the GLSL compiler can
+        be added by use of the `spirv_decorate`, `spirv_decorate_id`, or
+        `spirv_decorate_string` qualifiers.
+
+        This functionality is only available when generating SPIR-V.
+
+        The `spirv_decorate`, `spirv_decorate_id`, and
+        `spirv_decorate_string` qualifiers can be used on variable
+        declarations, function parameters, function return types,
+        and expressions (with "constructor" syntax).
+        `spirv_decorate_id` must not be used on structure member
+        declarations, but `spirv_decorate` and `spirv_decorate_string` can.
+
+        spirv_decorate-qualifier:
+
+            `spirv_decorate` ( integer-constant, spirv_decorate-parameter-list )
+            `spirv_decorate` ( spirv-requirements-list , integer-constant, spirv_decorate-parameter-list )
+            `spirv_decorate_id` ( integer-constant, spirv_decorate_id-parameter-list  )
+            `spirv_decorate_id` ( spirv-requirements-list , integer-constant, spirv_decorate_id-parameter-list  )
+            `spirv_decorate_string` ( integer-constant, spirv_decorate_string-parameter-list )
+            `spirv_decorate_string` ( spirv-requirements-list , integer-constant, spirv_decorate_string-parameter-list )
+
+        spirv_decorate-parameter-list:
+
+            spirv_decorate-parameter
+            spirv_decorate-parameter , spirv_decorate-parameter-list
+
+        spirv_decorate-parameter:
+
+            floating-constant
+            integer-constant
+            bool-constant
+
+        spirv_decorate_id-parameter-list:
+
+            constant-expression
+            constant-expression , spirv_decorate_id-parameter-list
+
+        spirv_decorate_string-parameter-list:
+
+            literal-string
+            literal-string , spirv_decorate_string-parameter-list
+
+        The `spirv_decorate` qualifier inserts an *OpDecorate* or
+        *OpMemberDecorate* instruction into the generated SPIR-V code,
+        taking the first integer parameter as its `Decoration` operand,
+        and further parameters as `Extra Operands`.
+        If the `spirv_decorate` qualifier is applied to a struct member,
+        *OpMemberDecorate* is inserted, otherwise *OpDecorate* is.
+        Integer and floating point values used must be expressible in a
+        32-bit range.
+        An error will be generated if the front-end compiler detects a
+        value outside of the 32-bit range.
+
+        The `spirv_decorate_id` qualifier inserts an *OpDecorateId*
+        instruction into the generated SPIR-V code, taking the first
+        integer parameter as its `Decoration` operand, and further
+        parameters as `Extra Operands`.
+        Parameters to this qualifier must be constant expressions as defined
+        in section 4.3.3, Constant Expressions.
+
+        The `spirv_decorate_string` qualifier inserts an *OpDecorateString*
+        or *OpMemberDecorateString* instruction into the generated SPIR-V
+        code, taking the first integer parameter as its `Decoration`
+        operand, the first string as the first `Literal` string argument,
+        and string parameters as `Optional Literals`.
+        If the `spirv_decorate_string` qualifier is applied to a struct
+        member, *OpMemberDecorateString* is inserted, otherwise
+        *OpDecorateString* is.
+
+        Any extensions or capabilities needed by the decoration must be
+        declared using SPIR-V Requirements Declarations (see section 3.9).
+
+        Multiple `spirv_decoration` qualifiers can be added to a single
+        declaration or expression.
+
+    Add a new section 4.14. SPIR-V Types
+
+        SPIR-V types not known to or exposed by the GLSL compiler can
+        be added by use of the `spirv_type` specifier.
+
+        This functionality is only available when generating SPIR-V.
+
+        The `spirv_type()` specifier can be used in place of a type name
+        for variable declarations.
+
+        spirv_type-specifier:
+
+            `spirv_type` ( spirv_instruction-qualifier-list )
+            `spirv_type` ( spirv_instruction-qualifier-list, spirv_type-parameter-list )
+            `spirv_type` ( spirv-requirements-list, spirv_instruction-qualifier-list )
+            `spirv_type` ( spirv-requirements-list, spirv_instruction-qualifier-list, spirv_type-parameter-list )
+
+        spirv_type-parameter-list:
+
+            spirv_type-parameter
+            spirv_type-parameter , spirv_type-parameter-list
+
+        spirv_type-parameter:
+
+            constant-expression
+            literal
+
+        spirv_instruction-qualifier-list:
+
+            spirv_instruction-qualifier
+            spirv_instruction-qualifier , spirv_instruction-qualifier-list
+
+        spirv_instruction-qualifier:
+
+            set = literal-string
+            id = integer-constant-expression
+
+        The `set` qualifier indicates the name of an extended
+        instruction set that the type's instruction belongs to.
+        If the `set` qualifier is omitted, or the string is empty,
+        no extended instruction set will be imported, and the instruction will
+        be selected from the core instruction set.
+
+        The `id` is the id of the type instruction in the selected
+        instruction set.
+
+        Parameters to this qualifier must be either literal values, or constant
+        expressions as defined in section 4.3.3, Constant Expressions.
+
+        When generating SPIR-V, the compiler will generate type
+        instructions for these types in the following manner:
+
+          * If any variable is declared with a SPIR-V type that requires an
+            extended instruction set (declared with the `set` qualifier),
+            it will add an *OpExtInstImport* instruction with the same
+            literal string.
+          * For variables declared with a SPIR-V type that requires an
+            extended instruction set, an *OpExtInst* instruction will be
+            inserted into the resulting SPIR-V, declaring the type.
+          * For variables declared with a SPIR-V type that is defined by
+            instructions in the core instruction set, an instruction with
+            the declared `id` will be inserted into the resulting SPIR-V.
+
+        Any extensions or capabilities needed by the type must be declared
+        using SPIR-V Requirements Declarations (see section 3.9).
+
+        Types declared in this way do not implicitly allow any usage other
+        than variable declaration and as function parameters, and cannot be
+        l-values.
+        When used as parameters in user-defined functions, spir-v will
+        always use pass-by-reference semantics (as if all the declaration
+        used the `spirv_by_reference` qualifier).
+        The `spirv_by_reference` qualifier must: still be present on
+        functions defined by the `spirv_instruction` qualifier that require
+        it.
+
+Additions to Chapter 6 of the OpenGL Shading Language Specification
+(Statements and Structure)
+
+    Modify section 6.1.1, Function Calling Conventions
+    
+        In the definition of `parameter-qualifier`, add the following:
+        
+            spirv_by_reference spirv_literal
+            
+        At the end of this section, add the following text:
+
+            When generating SPIR-V, the `spirv_by_reference` qualifier indicates
+            to the compiler that the variable should be passed as a SPIR-V
+            pointer rather than generating *OpLoad*/*OpStore* instructions
+            for the underlying object.
+            
+            When generating SPIR-V, the `spirv_literal` qualifier indicates
+            to the compiler that the variable should be compiled to a literal
+            value rather than a variable or constant with an id. Values passed
+            to such a parameter must be integer, boolean, or floating-point
+            constant expressions in the 32-bit range which can be evaluated by
+            the compiler front-end, and must not involve specialization
+            constants.
+            An error will be generated if the front-end compiler cannot generate
+            a literal 32-bit value.
+            Unlike `spirv_by_reference`, `spirv_literal` can only be used on
+            functions defined with `spirv_instruction`, and are invalid on
+            user-defined functions.
+
+    Add a new section 6.1.3, SPIR-V Instructions
+
+        SPIR-V instructions not known to or exposed by the GLSL compiler can be
+        accessed by use of the `spirv_instruction` qualifier, provided the shader
+        author knows the function signature and the id for the instruction
+        they want to use.
+        If the instruction is part of an extended instruction set, its name must
+        also be provided.
+
+        This functionality is only available when generating SPIR-V.
+
+        The `spirv_instruction` qualifier must always be used with a function
+        declaration that has a return type and parameters matching those of the
+        desired instruction.
+        If any parameters of the instruction should be passed by pointer
+        rather than by object, those parameters should additionally be
+        decorated with `spirv_by_reference`.
+        If any parameters of the instruction are literals, those parameters
+        should additionally be decorated with `spirv_literal`.
+
+        spirv_instruction-qualifier:
+
+            `spirv_instruction` ( spirv_instruction-qualifier-list )
+            `spirv_instruction` ( spirv-requirements-list, spirv_instruction-qualifier-list )
+
+        spirv_instruction-qualifier-list:
+
+            spirv_instruction-qualifier-id
+            spirv_instruction-qualifier-id , spirv_instruction-qualifier-list
+
+        spirv_instruction-qualifier-id:
+
+            set = literal-string
+            id = integer-constant-expression
+
+        The `set` qualifier indicates the name of an extended
+        instruction set that the instruction belongs to.
+        If the `set` qualifier is omitted, or the string is empty,
+        no extended instruction set will be imported, and the instruction will
+        be selected from the core instruction set.
+
+        The `id` is the id of the instruction in the selected instruction
+        set.
+
+        When generating SPIR-V, the compiler will generate additional
+        instructions for these instructions in the following manner:
+
+          * If any instruction requires an extended instruction set (declared
+            with the `set` qualifier), it will add an
+            *OpExtInstImport* instruction with the same literal string.
+          * For instructions requiring an extended instruction set, an
+            *OpExtInst* instruction will be inserted into the resulting SPIR-V.
+          * For instructions in the core instruction set, an instruction with
+            the declared `id` will be inserted into the resulting SPIR-V.
+
+        Any extensions or capabilities needed by the instruction must be
+        declared using SPIR-V Requirements Declarations (see section 3.9).
+
+Additions to Chapter 9 of the OpenGL Shading Language Specification
+(Shading Language Grammar)
+
+    Add the following tokens:
+
+        SPIRV_INSTRUCTION SPIRV_EXECUTION_MODE SPIRV_EXECUTION_MODE_ID
+        SPIRV_DECORATE SPIRV_DECORATE_ID SPIRV_DECORATE_STRING
+        SPIRV_STORAGE_CLASS SPIRV_BY_REFERENCE SPIRV_LITERAL
+
+    Add the following new rules:
+
+        spirv-requirements-list:
+            spirv-requirements-parameter
+            spirv-requirements-parameter COMMA spirv-requirements-list
+        
+        spirv-requirements-parameter:
+            IDENTIFIER EQUAL LEFT_BRACKET spirv-extension-list RIGHT_BRACKET
+            IDENTIFIER EQUAL LEFT_BRACKET spirv-capability-list RIGHT_BRACKET
+
+        spirv-capability-list:
+            INTCONSTANT
+            INTCONSTANT COMMA spirv-capability-list
+            
+        spirv-extension-list:
+            STRING_LITERAL
+            STRING_LITERAL COMMA spirv-extension-list
+        
+        spirv_execution_mode-qualifier:
+
+            SPIRV_EXECUTION_MODE LEFT_PAREN INTCONSTANT RIGHT_PAREN
+            SPIRV_EXECUTION_MODE LEFT_PAREN INTCONSTANT COMMA spirv_execution_mode-parameter-list RIGHT_PAREN
+            SPIRV_EXECUTION_MODE LEFT_PAREN spirv-requirements-list COMMA INTCONSTANT  RIGHT_PAREN
+            SPIRV_EXECUTION_MODE LEFT_PAREN spirv-requirements-list COMMA INTCONSTANT COMMA spirv_execution_mode-parameter-list RIGHT_PAREN
+            SPIRV_EXECUTION_MODE_ID LEFT_PAREN INTCONSTANT RIGHT_PAREN
+            SPIRV_EXECUTION_MODE_ID LEFT_PAREN INTCONSTANT COMMA spirv_execution_mode_id-parameter-list RIGHT_PAREN
+            SPIRV_EXECUTION_MODE_ID LEFT_PAREN INTCONSTANT COMMA spirv-requirements-list RIGHT_PAREN
+            SPIRV_EXECUTION_MODE_ID LEFT_PAREN INTCONSTANT COMMA spirv-requirements-list COMMA spirv_execution_mode_id-parameter-list RIGHT_PAREN
+
+        spirv_execution_mode-parameter-list:
+
+            spirv_execution_mode-parameter
+            spirv_execution_mode-parameter COMMA spirv_execution_mode-parameter-list
+
+        spirv_execution_mode-parameter:
+
+            FLOATCONSTANT
+            INTCONSTANT
+            UINTCONSTANT
+            BOOLCONSTANT
+            STRING_LITERAL
+
+        spirv_execution_mode_id-parameter-list:
+
+            constant-expression
+            constant-expression COMMA spirv_execution_mode_id-parameter-list
+
+        spirv_decorate-qualifier:
+
+            SPIRV_DECORATE LEFT_PAREN integer-constant COMMA spirv_decorate-parameter-list RIGHT_PAREN
+            SPIRV_DECORATE LEFT_PAREN spirv-requirements-list COMMA integer-constant COMMA spirv_decorate-parameter-list RIGHT_PAREN
+            SPIRV_DECORATE_ID LEFT_PAREN integer-constant COMMA spirv_decorate_id-parameter-list  RIGHT_PAREN
+            SPIRV_DECORATE_ID LEFT_PAREN spirv-requirements-list COMMA integer-constant COMMA spirv_decorate_id-parameter-list  RIGHT_PAREN
+            SPIRV_DECORATE_STRING LEFT_PAREN integer-constant COMMA spirv_decorate_string-parameter-list RIGHT_PAREN
+            SPIRV_DECORATE_STRING LEFT_PAREN spirv-requirements-list COMMA integer-constant COMMA spirv_decorate_string-parameter-list RIGHT_PAREN
+
+        spirv_decorate-parameter-list:
+
+            spirv_decorate-parameter
+            spirv_decorate-parameter COMMA spirv_decorate-parameter-list
+
+        spirv_decorate-parameter:
+
+            FLOATCONSTANT
+            INTCONSTANT
+            UINTCONSTANT
+            BOOLCONSTANT
+
+        spirv_decorate_id-parameter-list:
+
+            constant-expression
+            spirv_decorate_id-parameter-list COMMA constant-expression
+
+        spirv_decorate_string-parameter-list:
+
+            STRING_LITERAL
+            STRING_LITERAL COMMA spirv_decorate_string-parameter-list
+
+        spirv_type-specifier:
+
+            SPIRV_TYPE LEFT_PAREN spirv_instruction-qualifier-list RIGHT_PAREN
+            SPIRV_TYPE LEFT_PAREN spirv_instruction-qualifier-list COMMA spirv_type-parameter-list RIGHT_PAREN
+            SPIRV_TYPE LEFT_PAREN spirv-requirements-list COMMA spirv_instruction-qualifier-list RIGHT_PAREN
+            SPIRV_TYPE LEFT_PAREN spirv-requirements-list COMMA spirv_instruction-qualifier-list COMMA spirv_type-parameter-list RIGHT_PAREN
+
+        spirv_type-parameter-list:
+
+            spirv_type-parameter
+            spirv_type-parameter COMMA spirv_type-parameter-list
+
+        spirv_type-parameter:
+
+            constant-expression
+            INTCONSTANT
+            UINTCONSTANT
+            FLOATCONSTANT
+            BOOLCONSTANT
+            DOUBLECONSTANT
+
+        spirv_instruction-qualifier:
+
+            SPIRV_INSTRUCTION LEFT_PAREN spirv_instruction-qualifier-list RIGHT_PAREN
+            SPIRV_INSTRUCTION LEFT_PAREN spirv-requirements-list COMMA spirv_instruction-qualifier-list RIGHT_PAREN
+
+        spirv_instruction-qualifier-list:
+
+            spirv_instruction-qualifier-id
+            spirv_instruction-qualifier-id COMMA spirv_instruction-qualifier-list
+
+        spirv_instruction-qualifier-id:
+
+            IDENTIFIER EQUAL STRING_LITERAL
+            IDENTIFIER EQUAL constant_expression
+
+        spirv_storage_class-qualifier:
+            `spirv_storage_class` LEFT_PAREN integer-constant-expression RIGHT_PAREN
+            `spirv_storage_class` LEFT_PAREN spirv-requirements-list COMMA integer-constant-expression RIGHT_PAREN
+
+    Under the rule for storage_qualifier, add:
+    
+        spirv_storage_class-qualifier
+
+    Under the rule for single_type_qualifier, add:
+
+        spirv_storage_class-qualifier
+        spirv_decorate-qualifier
+        SPIRV_BY_REFERENCE
+        SPIRV_LITERAL
+
+    Under the rule for function_identifier, add:
+
+        spirv_decorate-qualifier
+
+    Under the rule for declaration, add:
+
+        spirv_instruction-qualifier function_prototype SEMICOLON
+        spirv_execution_mode-qualifier SEMICOLON
+
+    Under the rule for type_specifier_nonarray, add:
+
+        spirv_type-specifier
+
+Examples
+
+    Defining GL_ARB_shader_stencil_export via this extension:
+
+        #if defined(GL_FRAGMENT_SHADER)
+        #define GL_ARB_shader_stencil_export 1
+
+        spirv_execution_mode(extensions = ["SPV_EXT_shader_stencil_export"], capabilities = [5013], 5027);     
+
+        spirv_decorate (extensions = ["SPV_EXT_shader_stencil_export"], capabilities = [5013], 11, 5014)        
+        out int gl_FragStencilRefARB; 
+        #endif
+
+    Defining GL_EXT_shader_realtime_clock via this extension:
+
+        #define GL_EXT_shader_realtime_clock 1
+
+        uvec2 clockRealtime2x32EXT(void) {
+            spirv_instruction (extensions = ["SPV_KHR_shader_clock"], capabilities = [5055], id = 5056);
+            uvec2 clockRealtime2x32EXT_internal(uint scope);
+            
+            return clockRealtime2x32EXT_internal(1 /*Device scope*/);
+        }
+
+        #if defined(GL_EXT_shader_explicit_arithmetic_types_int64) || defined(GL_ARB_gpu_shader_int64) || defined(GL_AMD_gpu_shader_int64)
+        uint64_t clockRealtimeEXT(void) {
+            spirv_instruction (extensions = ["SPV_KHR_shader_clock"], capabilities = [5055], id = 5056);
+            uint64_t clockRealtimeEXT_internal(uint scope);
+            
+            return clockRealtimeEXT_internal(1 /*Device scope*/);
+        }
+        #endif
+
+    Defining GL_AMD_shader_trinary_minmax via this extension:
+
+        #define GL_AMD_shader_trinary_minmax 1
+
+        spirv_instruction (extensions = ["SPV_AMD_shader_trinary_minmax"], set = "SPV_AMD_shader_trinary_minmax", id = 1)
+        float min3(float x, float y, float z);
+        spirv_instruction (extensions = ["SPV_AMD_shader_trinary_minmax"], set = "SPV_AMD_shader_trinary_minmax", id = 1)
+        vec2 min3(vec2 x, vec2 y, vec2 z);
+        spirv_instruction (extensions = ["SPV_AMD_shader_trinary_minmax"], set = "SPV_AMD_shader_trinary_minmax", id = 1)
+        vec3 min3(vec3 x, vec3 y, vec3 z);
+        spirv_instruction (extensions = ["SPV_AMD_shader_trinary_minmax"], set = "SPV_AMD_shader_trinary_minmax", id = 1)
+        vec4 min3(vec4 x, vec4 y, vec4 z);
+
+        ...
+
+        // Note: This extension has more than 200 instruction variants, and for brevity they are not all listed here.
+
+    Defining GL_AMD_shader_explicit_vertex_parameter via this extension:
+
+        #if defined(GL_FRAGMENT_SHADER)
+        #define GL_AMD_shader_explicit_vertex_parameter 1
+
+        spirv_decorate (extensions = ["SPV_AMD_shader_explicit_vertex_parameter"], 11, 4992)
+        in vec2 gl_BaryCoordNoPerspAMD;
+        spirv_decorate (extensions = ["SPV_AMD_shader_explicit_vertex_parameter"], 11, 4993)
+        in vec2 gl_BaryCoordNoPerspCentroidAMD;
+        spirv_decorate (extensions = ["SPV_AMD_shader_explicit_vertex_parameter"], 11, 4994)
+        in vec2 gl_BaryCoordNoPerspSampleAMD;
+        spirv_decorate (extensions = ["SPV_AMD_shader_explicit_vertex_parameter"], 11, 4995)
+        in vec2 gl_BaryCoordSmoothAMD;
+        spirv_decorate (extensions = ["SPV_AMD_shader_explicit_vertex_parameter"], 11, 4996)
+        in vec2 gl_BaryCoordSmoothCentroidAMD;
+        spirv_decorate (extensions = ["SPV_AMD_shader_explicit_vertex_parameter"], 11, 4997)
+        in vec2 gl_BaryCoordSmoothSampleAMD;
+        spirv_decorate (extensions = ["SPV_AMD_shader_explicit_vertex_parameter"], 11, 4998)
+        in vec3 gl_BaryCoordPullModelAMD
+
+        #define __explicitInterpAMD spirv_decorate(extensions = ["SPV_AMD_shader_explicit_vertex_parameter"], 4999)
+
+        spirv_instruction (extensions = ["SPV_AMD_shader_explicit_vertex_parameter"], set = "SPV_AMD_shader_explicit_vertex_parameter", id = 1)
+        float interpolateAtVertexAMD(float interpolant, uint vertexIdx);
+        spirv_instruction (extensions = ["SPV_AMD_shader_explicit_vertex_parameter"], set = "SPV_AMD_shader_explicit_vertex_parameter", id = 1)
+        vec2 interpolateAtVertexAMD(vec2 interpolant, uint vertexIdx);
+        spirv_instruction (extensions = ["SPV_AMD_shader_explicit_vertex_parameter"], set = "SPV_AMD_shader_explicit_vertex_parameter", id = 1) 
+        vec3 interpolateAtVertexAMD(vec3 interpolant, uint vertexIdx);
+        spirv_instruction (extensions = ["SPV_AMD_shader_explicit_vertex_parameter"], set = "SPV_AMD_shader_explicit_vertex_parameter", id = 1)
+        vec4 interpolateAtVertexAMD(vec4 interpolant, uint vertexIdx);
+
+        ...
+
+        // Note: This extension has more than 200 instruction variants, and for brevity they are not all listed here.
+
+    Defining GLSL_EXT_ray_query via this extension:
+
+        #define GL_EXT_ray_query 1
+
+        #ifndef accelerationStructureEXT
+         // This definition conflicts with the GL_EXT_ray_tracing definition, but it should cause no problems in practice
+        #define accelerationStructureEXT spirv_type(extensions = ["SPV_KHR_ray_query"], capabilities = [4472], id = 5341)
+        #endif
+        
+        #define rayQueryEXT spirv_type (extensions = ["SPV_KHR_ray_query"], capabilities = [4472], id = 4472)
+
+        ...
+
+        spirv_instruction (extensions = ["SPV_KHR_ray_query"], capabilities = [4471, 4478], id = 4473)
+        void rayQueryInitializeEXT(spirv_by_reference rayQueryEXT rayQuery, accelerationStructureEXT topLevel, uint rayFlags, uint cullMask, vec3 origin, float tMin, vec3 direction, float tMax);
+
+        spirv_instruction (extensions = ["SPV_KHR_ray_query"], capabilities = [4472], id = 4477)
+        bool rayQueryProceedEXT(spirv_by_reference rayQueryEXT q);
+
+        ...
+
+        // Note: This extension also has a number of constants and intrinsic functions which are not all listed here.
+
+    Defining GLSL_EXT_ray_tracing via this extension:
+
+        #if defined(GL_RAY_GENERATION_SHADER_EXT) || defined(GL_INTERSECTION_SHADER_EXT) || defined(GL_ANY_HIT_SHADER_EXT) || defined(GL_CLOSEST_HIT_SHADER_EXT) || defined(GL_MISS_SHADER_EXT) || defined(GL_CALLABLE_SHADER_EXT)
+        #define GL_EXT_ray_tracing 1
+
+        #ifndef accelerationStructureEXT
+        // This definition conflicts with the GL_EXT_ray_query definition, but it should cause no problems in practice
+        #define accelerationStructureEXT spirv_type(extensions = ["SPV_KHR_ray_tracing"], capabilities = [5353], id = 5341)
+        #endif
+
+        #if defined(GL_RAY_GENERATION_SHADER_EXT) || defined(GL_CLOSEST_HIT_SHADER_EXT) || defined(GL_MISS_SHADER_EXT)
+        #define rayPayloadEXT spirv_storage_class(extensions = ["SPV_KHR_ray_tracing"], capabilities = [5353], 5338)
+        #endif
+        #if defined(GL_ANY_HIT_SHADER_EXT) || defined(GL_CLOSEST_HIT_SHADER_EXT) || defined(GL_MISS_SHADER_EXT)
+        #define rayPayloadInEXT spirv_storage_class(extensions = ["SPV_KHR_ray_tracing"], capabilities = [5353], 5342)
+        #endif
+        #if defined(GL_ANY_HIT_SHADER_EXT) || defined(GL_CLOSEST_HIT_SHADER_EXT) || defined(GL_INTERSECTION_SHADER_EXT)
+        #define hitAttributeEXT spirv_storage_class(extensions = ["SPV_KHR_ray_tracing"], capabilities = [5353], 5339)
+        #endif
+        #if defined(GL_RAY_GENERATION_SHADER_EXT) || defined(GL_CLOSEST_HIT_SHADER_EXT) || defined(GL_MISS_SHADER_EXT) || defined((GL_CALLABLE_SHADER)
+        #define callableDataEXT spirv_storage_class(extensions = ["SPV_KHR_ray_tracing"], capabilities = [5353], 5328)
+        #endif
+        #ifdef(GL_CALLABLE_SHADER)
+        #define callableDataInEXT spirv_storage_class(extensions = ["SPV_KHR_ray_tracing"], capabilities = [5353], 5329)
+        #endif
+        #define shaderRecordEXT spirv_storage_class(extensions = ["SPV_KHR_ray_tracing"], capabilities = [5353], 5343)
+
+        ...
+
+        // Note: This extension also has a number of constants, built-ins, and intrinsic functions which are not all listed here.
+        
+    Defining the modf instruction via this extension:
+    
+        spirv_instruction (set = "GLSL.std.450", id = 35) // modf
+        float modf(float x, spirv_by_reference float i);
+    
+    Example shader using spirv_literal:
+    
+        #version 450 core
+
+        #extension GL_EXT_spirv_intrinsics: enable
+
+        spirv_instruction(id = 61)
+        vec4 load(spirv_by_reference vec4 pointer, spirv_literal int memoryOperands);
+
+        spirv_instruction(id = 62)
+        void store(spirv_by_reference vec4 pointer, vec4 object, spirv_literal int memoryOperands);
+
+        layout(location = 0) in vec4 vec4In;
+        layout(location = 1) out vec4 vec4Out;
+
+        void main()
+        {
+            store(vec4Out, load(vec4In, /*None=*/0x0), /*Volatile=*/0x1);
+        }
+
+
+Issues
+
+    1) Are new layout qualifiers the right way to handle extensions,
+       capabilities, decorations, and execution modes?
+
+    PROPOSED: Yes
+
+    There are a number of other ways this could be done, but other
+    obvious alternatives had drawbacks.
+    Initially pragmas or other preprocessor methods were considered but these
+    could not be used with features such as specialization constants, which
+    are legal with things like *OpExecutionModeId*.
+
+    Pragmas and preprocessor mechanisms like #extension also don't allow
+    macro expansion, so you wouldn't be able to make user-friendly
+    definitions for the various otherwise unnamed integer parameters in the
+    API.
+
+    2) Are there any other things that could be added this way?
+
+    PROPOSED
+
+    Memory, Execution, and Addressing Models could be potentially
+    advertised, but these could result in quite drastic changes to the
+    generated SPIR-V, so it's not clear that it makes sense to do this way.
+
+    In addition, memory and execution model are both handled outside of the
+    language with current GLSL tools and compilers - this would need
+    resolution in some way.
+
+    3) How does error handling in GLSL factor in?
+
+    PROPOSED
+
+    GLSL can perform basic syntax checks with the instructions and built-ins
+    based on the user provided definitions, but is unable to validate that
+    any of these are used correctly with regards to the SPIR-V
+    specification.
+    
+    One particular example would be that there is no validation that the
+    right capabilities and extensions are enabled for the functionality
+    being used.
+
+    Shader authors using this extension directly thus need to take care
+    that the output is valid, and it is strongly recommended that the
+    generated SPIR-V is validated by a tool such as spirv-val to ensure
+    correct output.
+
+    4) Would this enable SPIR-V extensions to be used by generating a simple
+    header file?
+
+    PROPOSED
+
+    For many extensions, and indeed this is the intent.
+    There are some limitations as per issues 2 and 6, and there's less
+    error checking than a native implementation as per issue 3, but most
+    extensions could be defined this way.
+    A GLSL specification would also still be necessary to describe the
+    behavior properly.
+
+    5) Is this new use of "set" the right approach?
+
+    PROPOSED
+
+    Initially "set" and "id" were "instruction_set" and "instruction_id",
+    but these make the qualifier lines unnecessarily long for something
+    that is already known by context to both the compiler and readers.
+    "inst_set" and "inst_id" have also been considered.
+
+    6) Are there any known limitations in extension definitions that would be hard to resolve?
+
+    RESOLVED: Yes
+
+    The main issue spotted so far is any keywords that are applied to a variable
+    (e.g. `shadercallcoherent`) in GLSL but are applied to particular
+    operations in SPIR-V (e.g. `ShaderCallKHR` scope).
+
+    This extension isn't designed as a replacement for language features
+    however, so this type of restriction seems fine. The functionality in
+    the example can be achieved directly by adding a new "scope" constant.
+
+Revision History
+
+    Rev.    Date      Author   Changes
+    ----  ----------  -------  -----------------------------------------------
+     1    2020-08-21  thector  Initial revision
+     2    2021-01-21  thector  Added spirv_literal qualifier
+     3    2021-01-21  thector  Moved extension/capabilities to be specified on
+                               intrinsics as requirements rather than preamble  
+     4    2021-02-22  thector  Allowed GL_* macros to be defined.
+                               Added missing spirv_execution_mode rule.
+                               Fixed parameter ordering for spirv_execution_mode
+                               and spirv_decorate.
+                               Fixed ARB_shader_stencil_export example.
+     5    2021-02-26  thector  Allowed gl_* identifiers to be defined.
+                               Fixed ray query capability number.
+                               Modified instruction/type qualifiers to accept
+                               requirements lists in the same manner as other
+                               qualifiers.
+                               Added spirv_literal example to spec text.
+     6    2021-03-02  thector  Fixed spirv_storage_class grammar, added
+                               requirements declarations.
+                               Restricted spirv_literal parameters further.
+                               Removed broken spirv_literal example.
+     7    2021-03-02  thector  Added spirv_literal example.
+                               Updated contributor list.

--- a/extensions/ext/GLSL_EXT_spirv_intrinsics.txt
+++ b/extensions/ext/GLSL_EXT_spirv_intrinsics.txt
@@ -262,6 +262,10 @@ Additions to Chapter 3 of the OpenGL Shading Language Specification
         generated SPIR-V.
         These qualifiers must be declared at global scope.
 
+        Any extensions or capabilities needed by the execution mode must be declared
+        using the optional spirv-requirements-list as described in section 3.9
+        (SPIR-V Requirements Declarations).
+        
         spirv_execution_mode-qualifier:
         
             `spirv_execution_mode` ( integer-constant-expression )
@@ -336,6 +340,10 @@ Additions to Chapter 4 of the OpenGL Shading Language Specification
 
         This functionality is only available when generating SPIR-V.
 
+        Any extensions or capabilities needed by the storage class must be declared
+        using the optional spirv-requirements-list as described in section 3.9
+        (SPIR-V Requirements Declarations).
+        
         The `spirv_storage_class` qualifier can only be used on variable
         declarations at global scope.
 
@@ -359,6 +367,10 @@ Additions to Chapter 4 of the OpenGL Shading Language Specification
 
         This functionality is only available when generating SPIR-V.
 
+        Any extensions or capabilities needed by the decoration must be declared
+        using the optional spirv-requirements-list as described in section 3.9
+        (SPIR-V Requirements Declarations).
+        
         The `spirv_decorate`, `spirv_decorate_id`, and
         `spirv_decorate_string` qualifiers can be used on variable
         declarations, function parameters, function return types,
@@ -411,8 +423,9 @@ Additions to Chapter 4 of the OpenGL Shading Language Specification
         instruction into the generated SPIR-V code, taking the first
         integer parameter as its `Decoration` operand, and further
         parameters as `Extra Operands`.
-        Parameters to this qualifier must be constant expressions as defined
-        in section 4.3.3, Constant Expressions.
+        Parameters to this qualifier must be a constant expression that
+        doesn't involve a specialization constant, as defined in section
+        4.3.3, Constant Expressions.
 
         The `spirv_decorate_string` qualifier inserts an *OpDecorateString*
         or *OpMemberDecorateString* instruction into the generated SPIR-V
@@ -435,6 +448,10 @@ Additions to Chapter 4 of the OpenGL Shading Language Specification
         be added by use of the `spirv_type` specifier.
 
         This functionality is only available when generating SPIR-V.
+        
+        Any extensions or capabilities needed by the type must be declared
+        using the optional spirv-requirements-list as described in section 3.9
+        (SPIR-V Requirements Declarations).
 
         The `spirv_type()` specifier can be used in place of a type name
         for variable declarations.
@@ -489,7 +506,8 @@ Additions to Chapter 4 of the OpenGL Shading Language Specification
             inserted into the resulting SPIR-V, declaring the type.
           * For variables declared with a SPIR-V type that is defined by
             instructions in the core instruction set, an instruction with
-            the declared `id` will be inserted into the resulting SPIR-V.
+            the declared `id` as its opcode will be inserted into the
+            resulting SPIR-V.
 
         Any extensions or capabilities needed by the type must be declared
         using SPIR-V Requirements Declarations (see section 3.9).
@@ -545,6 +563,10 @@ Additions to Chapter 6 of the OpenGL Shading Language Specification
 
         This functionality is only available when generating SPIR-V.
 
+        Any extensions or capabilities needed by the instruction must be declared
+        using the optional spirv-requirements-list as described in section 3.9
+        (SPIR-V Requirements Declarations).
+        
         The `spirv_instruction` qualifier must always be used with a function
         declaration that has a return type and parameters matching those of the
         desired instruction.

--- a/extensions/ext/GLSL_EXT_spirv_intrinsics.txt
+++ b/extensions/ext/GLSL_EXT_spirv_intrinsics.txt
@@ -247,14 +247,10 @@ Additions to Chapter 3 of the OpenGL Shading Language Specification
             literal-string
             literal-string , spirv-extension-list
 
-        The `extensions` qualifier declares a list of SPIR-V extensions
-        that are required to use this instruction.
         An *OpExtension* instruction will be inserted into the generated
         SPIR-V code for each declared extension with the string parameter
         as its `Name` operand, if it is not already present.
 
-        The `capabilities` qualifier declares a list of SPIR-V capabilities
-        that are required to use this instruction.
         An *OpCapability* instruction will be inserted into the generated
         SPIR-V code for each declared capability with the integer parameter
         as its `Capability` operand, if it is not already present.
@@ -525,12 +521,13 @@ Additions to Chapter 6 of the OpenGL Shading Language Specification
             for the underlying object.
             
             When generating SPIR-V, the `spirv_literal` qualifier indicates
-            to the compiler that the variable should be compiled to a literal
-            value rather than a variable or constant with an id. Values passed
-            to such a parameter must be integer, boolean, or floating-point
-            constant expressions in the 32-bit range which can be evaluated by
-            the compiler front-end, and must not involve specialization
-            constants.
+            to the compiler that the value passed to the parameter should be
+            compiled to a literal value rather than a variable or constant with
+            an id.
+            Values passed to such a parameter must be integer, boolean, or
+            floating-point constant expressions in the 32-bit range which can
+            be evaluated by the compiler front-end, and must not involve
+            specialization constants.
             An error will be generated if the front-end compiler cannot generate
             a literal 32-bit value.
             Unlike `spirv_by_reference`, `spirv_literal` can only be used on

--- a/extensions/extension_headers/GL_AMD_shader_explicit_vertex_parameter.glsl
+++ b/extensions/extension_headers/GL_AMD_shader_explicit_vertex_parameter.glsl
@@ -1,0 +1,110 @@
+#if defined(GL_FRAGMENT_SHADER)
+#define GL_AMD_shader_explicit_vertex_parameter 1
+
+spirv_decorate (extensions = ["SPV_AMD_shader_explicit_vertex_parameter"], 11, 4992) 
+in vec2 gl_BaryCoordNoPerspAMD;
+spirv_decorate (extensions = ["SPV_AMD_shader_explicit_vertex_parameter"], 11, 4993) 
+in vec2 gl_BaryCoordNoPerspCentroidAMD;
+spirv_decorate (extensions = ["SPV_AMD_shader_explicit_vertex_parameter"], 11, 4994) 
+in vec2 gl_BaryCoordNoPerspSampleAMD;
+spirv_decorate (extensions = ["SPV_AMD_shader_explicit_vertex_parameter"], 11, 4995) 
+in vec2 gl_BaryCoordSmoothAMD;
+spirv_decorate (extensions = ["SPV_AMD_shader_explicit_vertex_parameter"], 11, 4996) 
+in vec2 gl_BaryCoordSmoothCentroidAMD;
+spirv_decorate (extensions = ["SPV_AMD_shader_explicit_vertex_parameter"], 11, 4997) 
+in vec2 gl_BaryCoordSmoothSampleAMD;
+spirv_decorate (extensions = ["SPV_AMD_shader_explicit_vertex_parameter"], 11, 4998) 
+in vec3 gl_BaryCoordPullModelAMD
+
+#define __explicitInterpAMD spirv_decorate (extensions = ["SPV_AMD_shader_explicit_vertex_parameter"], 4999)
+
+spirv_instruction (extensions = ["SPV_AMD_shader_explicit_vertex_parameter"], set = "SPV_AMD_shader_explicit_vertex_parameter", id = 1) float interpolateAtVertexAMD(float interpolant, uint vertexIdx);
+spirv_instruction (extensions = ["SPV_AMD_shader_explicit_vertex_parameter"], set = "SPV_AMD_shader_explicit_vertex_parameter", id = 1) vec2 interpolateAtVertexAMD(vec2 interpolant, uint vertexIdx);
+spirv_instruction (extensions = ["SPV_AMD_shader_explicit_vertex_parameter"], set = "SPV_AMD_shader_explicit_vertex_parameter", id = 1) vec3 interpolateAtVertexAMD(vec3 interpolant, uint vertexIdx);
+spirv_instruction (extensions = ["SPV_AMD_shader_explicit_vertex_parameter"], set = "SPV_AMD_shader_explicit_vertex_parameter", id = 1) vec4 interpolateAtVertexAMD(vec4 interpolant, uint vertexIdx);
+spirv_instruction (extensions = ["SPV_AMD_shader_explicit_vertex_parameter"], set = "SPV_AMD_shader_explicit_vertex_parameter", id = 1) mat2x2 interpolateAtVertexAMD(mat2x2 interpolant, uint vertexIdx);
+spirv_instruction (extensions = ["SPV_AMD_shader_explicit_vertex_parameter"], set = "SPV_AMD_shader_explicit_vertex_parameter", id = 1) mat2x3 interpolateAtVertexAMD(mat2x3 interpolant, uint vertexIdx);
+spirv_instruction (extensions = ["SPV_AMD_shader_explicit_vertex_parameter"], set = "SPV_AMD_shader_explicit_vertex_parameter", id = 1) mat2x4 interpolateAtVertexAMD(mat2x4 interpolant, uint vertexIdx);
+spirv_instruction (extensions = ["SPV_AMD_shader_explicit_vertex_parameter"], set = "SPV_AMD_shader_explicit_vertex_parameter", id = 1) mat3x2 interpolateAtVertexAMD(mat3x2 interpolant, uint vertexIdx);
+spirv_instruction (extensions = ["SPV_AMD_shader_explicit_vertex_parameter"], set = "SPV_AMD_shader_explicit_vertex_parameter", id = 1) mat3x3 interpolateAtVertexAMD(mat3x3 interpolant, uint vertexIdx);
+spirv_instruction (extensions = ["SPV_AMD_shader_explicit_vertex_parameter"], set = "SPV_AMD_shader_explicit_vertex_parameter", id = 1) mat3x4 interpolateAtVertexAMD(mat3x4 interpolant, uint vertexIdx);
+spirv_instruction (extensions = ["SPV_AMD_shader_explicit_vertex_parameter"], set = "SPV_AMD_shader_explicit_vertex_parameter", id = 1) mat4x2 interpolateAtVertexAMD(mat4x2 interpolant, uint vertexIdx);
+spirv_instruction (extensions = ["SPV_AMD_shader_explicit_vertex_parameter"], set = "SPV_AMD_shader_explicit_vertex_parameter", id = 1) mat4x3 interpolateAtVertexAMD(mat4x3 interpolant, uint vertexIdx);
+spirv_instruction (extensions = ["SPV_AMD_shader_explicit_vertex_parameter"], set = "SPV_AMD_shader_explicit_vertex_parameter", id = 1) mat4x4 interpolateAtVertexAMD(mat4x4 interpolant, uint vertexIdx);
+
+#if defined(GL_AMD_gpu_shader_half_float) || defined(GL_EXT_shader_explicit_arithmetic_types_float16)
+spirv_instruction (extensions = ["SPV_AMD_shader_explicit_vertex_parameter"], set = "SPV_AMD_shader_explicit_vertex_parameter", id = 1) float16_t interpolateAtVertexAMD(float16_t interpolant, uint vertexIdx);
+spirv_instruction (extensions = ["SPV_AMD_shader_explicit_vertex_parameter"], set = "SPV_AMD_shader_explicit_vertex_parameter", id = 1) f16vec2 interpolateAtVertexAMD(f16vec2 interpolant, uint vertexIdx);
+spirv_instruction (extensions = ["SPV_AMD_shader_explicit_vertex_parameter"], set = "SPV_AMD_shader_explicit_vertex_parameter", id = 1) f16vec3 interpolateAtVertexAMD(f16vec3 interpolant, uint vertexIdx);
+spirv_instruction (extensions = ["SPV_AMD_shader_explicit_vertex_parameter"], set = "SPV_AMD_shader_explicit_vertex_parameter", id = 1) f16vec4 interpolateAtVertexAMD(f16vec4 interpolant, uint vertexIdx);
+spirv_instruction (extensions = ["SPV_AMD_shader_explicit_vertex_parameter"], set = "SPV_AMD_shader_explicit_vertex_parameter", id = 1) f16mat2x2 interpolateAtVertexAMD(f16mat2x2 interpolant, uint vertexIdx);
+spirv_instruction (extensions = ["SPV_AMD_shader_explicit_vertex_parameter"], set = "SPV_AMD_shader_explicit_vertex_parameter", id = 1) f16mat2x3 interpolateAtVertexAMD(f16mat2x3 interpolant, uint vertexIdx);
+spirv_instruction (extensions = ["SPV_AMD_shader_explicit_vertex_parameter"], set = "SPV_AMD_shader_explicit_vertex_parameter", id = 1) f16mat2x4 interpolateAtVertexAMD(f16mat2x4 interpolant, uint vertexIdx);
+spirv_instruction (extensions = ["SPV_AMD_shader_explicit_vertex_parameter"], set = "SPV_AMD_shader_explicit_vertex_parameter", id = 1) f16mat3x2 interpolateAtVertexAMD(f16mat3x2 interpolant, uint vertexIdx);
+spirv_instruction (extensions = ["SPV_AMD_shader_explicit_vertex_parameter"], set = "SPV_AMD_shader_explicit_vertex_parameter", id = 1) f16mat3x3 interpolateAtVertexAMD(f16mat3x3 interpolant, uint vertexIdx);
+spirv_instruction (extensions = ["SPV_AMD_shader_explicit_vertex_parameter"], set = "SPV_AMD_shader_explicit_vertex_parameter", id = 1) f16mat3x4 interpolateAtVertexAMD(f16mat3x4 interpolant, uint vertexIdx);
+spirv_instruction (extensions = ["SPV_AMD_shader_explicit_vertex_parameter"], set = "SPV_AMD_shader_explicit_vertex_parameter", id = 1) f16mat4x2 interpolateAtVertexAMD(f16mat4x2 interpolant, uint vertexIdx);
+spirv_instruction (extensions = ["SPV_AMD_shader_explicit_vertex_parameter"], set = "SPV_AMD_shader_explicit_vertex_parameter", id = 1) f16mat4x3 interpolateAtVertexAMD(f16mat4x3 interpolant, uint vertexIdx);
+spirv_instruction (extensions = ["SPV_AMD_shader_explicit_vertex_parameter"], set = "SPV_AMD_shader_explicit_vertex_parameter", id = 1) f16mat4x4 interpolateAtVertexAMD(f16mat4x4 interpolant, uint vertexIdx);
+#endif
+
+spirv_instruction (extensions = ["SPV_AMD_shader_explicit_vertex_parameter"], set = "SPV_AMD_shader_explicit_vertex_parameter", id = 1) uint interpolateAtVertexAMD(uint interpolant, uint vertexIdx);
+spirv_instruction (extensions = ["SPV_AMD_shader_explicit_vertex_parameter"], set = "SPV_AMD_shader_explicit_vertex_parameter", id = 1) uvec2 interpolateAtVertexAMD(uvec2 interpolant, uint vertexIdx);
+spirv_instruction (extensions = ["SPV_AMD_shader_explicit_vertex_parameter"], set = "SPV_AMD_shader_explicit_vertex_parameter", id = 1) uvec3 interpolateAtVertexAMD(uvec3 interpolant, uint vertexIdx);
+spirv_instruction (extensions = ["SPV_AMD_shader_explicit_vertex_parameter"], set = "SPV_AMD_shader_explicit_vertex_parameter", id = 1) uvec4 interpolateAtVertexAMD(uvec4 interpolant, uint vertexIdx);
+spirv_instruction (extensions = ["SPV_AMD_shader_explicit_vertex_parameter"], set = "SPV_AMD_shader_explicit_vertex_parameter", id = 1) umat2x2 interpolateAtVertexAMD(umat2x2 interpolant, uint vertexIdx);
+spirv_instruction (extensions = ["SPV_AMD_shader_explicit_vertex_parameter"], set = "SPV_AMD_shader_explicit_vertex_parameter", id = 1) umat2x3 interpolateAtVertexAMD(umat2x3 interpolant, uint vertexIdx);
+spirv_instruction (extensions = ["SPV_AMD_shader_explicit_vertex_parameter"], set = "SPV_AMD_shader_explicit_vertex_parameter", id = 1) umat2x4 interpolateAtVertexAMD(umat2x4 interpolant, uint vertexIdx);
+spirv_instruction (extensions = ["SPV_AMD_shader_explicit_vertex_parameter"], set = "SPV_AMD_shader_explicit_vertex_parameter", id = 1) umat3x2 interpolateAtVertexAMD(umat3x2 interpolant, uint vertexIdx);
+spirv_instruction (extensions = ["SPV_AMD_shader_explicit_vertex_parameter"], set = "SPV_AMD_shader_explicit_vertex_parameter", id = 1) umat3x3 interpolateAtVertexAMD(umat3x3 interpolant, uint vertexIdx);
+spirv_instruction (extensions = ["SPV_AMD_shader_explicit_vertex_parameter"], set = "SPV_AMD_shader_explicit_vertex_parameter", id = 1) umat3x4 interpolateAtVertexAMD(umat3x4 interpolant, uint vertexIdx);
+spirv_instruction (extensions = ["SPV_AMD_shader_explicit_vertex_parameter"], set = "SPV_AMD_shader_explicit_vertex_parameter", id = 1) umat4x2 interpolateAtVertexAMD(umat4x2 interpolant, uint vertexIdx);
+spirv_instruction (extensions = ["SPV_AMD_shader_explicit_vertex_parameter"], set = "SPV_AMD_shader_explicit_vertex_parameter", id = 1) umat4x3 interpolateAtVertexAMD(umat4x3 interpolant, uint vertexIdx);
+spirv_instruction (extensions = ["SPV_AMD_shader_explicit_vertex_parameter"], set = "SPV_AMD_shader_explicit_vertex_parameter", id = 1) umat4x4 interpolateAtVertexAMD(umat4x4 interpolant, uint vertexIdx);
+
+#if defined(GL_EXT_shader_explicit_arithmetic_types_int16)
+spirv_instruction (extensions = ["SPV_AMD_shader_explicit_vertex_parameter"], set = "SPV_AMD_shader_explicit_vertex_parameter", id = 1) uint16_t interpolateAtVertexAMD(uint16_t interpolant, uint vertexIdx);
+spirv_instruction (extensions = ["SPV_AMD_shader_explicit_vertex_parameter"], set = "SPV_AMD_shader_explicit_vertex_parameter", id = 1) u16vec2 interpolateAtVertexAMD(u16vec2 interpolant, uint vertexIdx);
+spirv_instruction (extensions = ["SPV_AMD_shader_explicit_vertex_parameter"], set = "SPV_AMD_shader_explicit_vertex_parameter", id = 1) u16vec3 interpolateAtVertexAMD(u16vec3 interpolant, uint vertexIdx);
+spirv_instruction (extensions = ["SPV_AMD_shader_explicit_vertex_parameter"], set = "SPV_AMD_shader_explicit_vertex_parameter", id = 1) u16vec4 interpolateAtVertexAMD(u16vec4 interpolant, uint vertexIdx);
+spirv_instruction (extensions = ["SPV_AMD_shader_explicit_vertex_parameter"], set = "SPV_AMD_shader_explicit_vertex_parameter", id = 1) u16mat2x2 interpolateAtVertexAMD(u16mat2x2 interpolant, uint vertexIdx);
+spirv_instruction (extensions = ["SPV_AMD_shader_explicit_vertex_parameter"], set = "SPV_AMD_shader_explicit_vertex_parameter", id = 1) u16mat2x3 interpolateAtVertexAMD(u16mat2x3 interpolant, uint vertexIdx);
+spirv_instruction (extensions = ["SPV_AMD_shader_explicit_vertex_parameter"], set = "SPV_AMD_shader_explicit_vertex_parameter", id = 1) u16mat2x4 interpolateAtVertexAMD(u16mat2x4 interpolant, uint vertexIdx);
+spirv_instruction (extensions = ["SPV_AMD_shader_explicit_vertex_parameter"], set = "SPV_AMD_shader_explicit_vertex_parameter", id = 1) u16mat3x2 interpolateAtVertexAMD(u16mat3x2 interpolant, uint vertexIdx);
+spirv_instruction (extensions = ["SPV_AMD_shader_explicit_vertex_parameter"], set = "SPV_AMD_shader_explicit_vertex_parameter", id = 1) u16mat3x3 interpolateAtVertexAMD(u16mat3x3 interpolant, uint vertexIdx);
+spirv_instruction (extensions = ["SPV_AMD_shader_explicit_vertex_parameter"], set = "SPV_AMD_shader_explicit_vertex_parameter", id = 1) u16mat3x4 interpolateAtVertexAMD(u16mat3x4 interpolant, uint vertexIdx);
+spirv_instruction (extensions = ["SPV_AMD_shader_explicit_vertex_parameter"], set = "SPV_AMD_shader_explicit_vertex_parameter", id = 1) u16mat4x2 interpolateAtVertexAMD(u16mat4x2 interpolant, uint vertexIdx);
+spirv_instruction (extensions = ["SPV_AMD_shader_explicit_vertex_parameter"], set = "SPV_AMD_shader_explicit_vertex_parameter", id = 1) u16mat4x3 interpolateAtVertexAMD(u16mat4x3 interpolant, uint vertexIdx);
+spirv_instruction (extensions = ["SPV_AMD_shader_explicit_vertex_parameter"], set = "SPV_AMD_shader_explicit_vertex_parameter", id = 1) u16mat4x4 interpolateAtVertexAMD(u16mat4x4 interpolant, uint vertexIdx);
+#endif
+
+spirv_instruction (extensions = ["SPV_AMD_shader_explicit_vertex_parameter"], set = "SPV_AMD_shader_explicit_vertex_parameter", id = 1) int interpolateAtVertexAMD(int interpolant, uint vertexIdx);
+spirv_instruction (extensions = ["SPV_AMD_shader_explicit_vertex_parameter"], set = "SPV_AMD_shader_explicit_vertex_parameter", id = 1) ivec2 interpolateAtVertexAMD(ivec2 interpolant, uint vertexIdx);
+spirv_instruction (extensions = ["SPV_AMD_shader_explicit_vertex_parameter"], set = "SPV_AMD_shader_explicit_vertex_parameter", id = 1) ivec3 interpolateAtVertexAMD(ivec3 interpolant, uint vertexIdx);
+spirv_instruction (extensions = ["SPV_AMD_shader_explicit_vertex_parameter"], set = "SPV_AMD_shader_explicit_vertex_parameter", id = 1) ivec4 interpolateAtVertexAMD(ivec4 interpolant, uint vertexIdx);
+spirv_instruction (extensions = ["SPV_AMD_shader_explicit_vertex_parameter"], set = "SPV_AMD_shader_explicit_vertex_parameter", id = 1) imat2x2 interpolateAtVertexAMD(imat2x2 interpolant, uint vertexIdx);
+spirv_instruction (extensions = ["SPV_AMD_shader_explicit_vertex_parameter"], set = "SPV_AMD_shader_explicit_vertex_parameter", id = 1) imat2x3 interpolateAtVertexAMD(imat2x3 interpolant, uint vertexIdx);
+spirv_instruction (extensions = ["SPV_AMD_shader_explicit_vertex_parameter"], set = "SPV_AMD_shader_explicit_vertex_parameter", id = 1) imat2x4 interpolateAtVertexAMD(imat2x4 interpolant, uint vertexIdx);
+spirv_instruction (extensions = ["SPV_AMD_shader_explicit_vertex_parameter"], set = "SPV_AMD_shader_explicit_vertex_parameter", id = 1) imat3x2 interpolateAtVertexAMD(imat3x2 interpolant, uint vertexIdx);
+spirv_instruction (extensions = ["SPV_AMD_shader_explicit_vertex_parameter"], set = "SPV_AMD_shader_explicit_vertex_parameter", id = 1) imat3x3 interpolateAtVertexAMD(imat3x3 interpolant, uint vertexIdx);
+spirv_instruction (extensions = ["SPV_AMD_shader_explicit_vertex_parameter"], set = "SPV_AMD_shader_explicit_vertex_parameter", id = 1) imat3x4 interpolateAtVertexAMD(imat3x4 interpolant, uint vertexIdx);
+spirv_instruction (extensions = ["SPV_AMD_shader_explicit_vertex_parameter"], set = "SPV_AMD_shader_explicit_vertex_parameter", id = 1) imat4x2 interpolateAtVertexAMD(imat4x2 interpolant, uint vertexIdx);
+spirv_instruction (extensions = ["SPV_AMD_shader_explicit_vertex_parameter"], set = "SPV_AMD_shader_explicit_vertex_parameter", id = 1) imat4x3 interpolateAtVertexAMD(imat4x3 interpolant, uint vertexIdx);
+spirv_instruction (extensions = ["SPV_AMD_shader_explicit_vertex_parameter"], set = "SPV_AMD_shader_explicit_vertex_parameter", id = 1) imat4x4 interpolateAtVertexAMD(imat4x4 interpolant, uint vertexIdx);
+
+#if defined(GL_EXT_shader_explicit_arithmetic_types_int16)
+spirv_instruction (extensions = ["SPV_AMD_shader_explicit_vertex_parameter"], set = "SPV_AMD_shader_explicit_vertex_parameter", id = 1) int16_t interpolateAtVertexAMD(int16_t interpolant, uint vertexIdx);
+spirv_instruction (extensions = ["SPV_AMD_shader_explicit_vertex_parameter"], set = "SPV_AMD_shader_explicit_vertex_parameter", id = 1) i16vec2 interpolateAtVertexAMD(i16vec2 interpolant, uint vertexIdx);
+spirv_instruction (extensions = ["SPV_AMD_shader_explicit_vertex_parameter"], set = "SPV_AMD_shader_explicit_vertex_parameter", id = 1) i16vec3 interpolateAtVertexAMD(i16vec3 interpolant, uint vertexIdx);
+spirv_instruction (extensions = ["SPV_AMD_shader_explicit_vertex_parameter"], set = "SPV_AMD_shader_explicit_vertex_parameter", id = 1) i16vec4 interpolateAtVertexAMD(i16vec4 interpolant, uint vertexIdx);
+spirv_instruction (extensions = ["SPV_AMD_shader_explicit_vertex_parameter"], set = "SPV_AMD_shader_explicit_vertex_parameter", id = 1) i16mat2x2 interpolateAtVertexAMD(i16mat2x2 interpolant, uint vertexIdx);
+spirv_instruction (extensions = ["SPV_AMD_shader_explicit_vertex_parameter"], set = "SPV_AMD_shader_explicit_vertex_parameter", id = 1) i16mat2x3 interpolateAtVertexAMD(i16mat2x3 interpolant, uint vertexIdx);
+spirv_instruction (extensions = ["SPV_AMD_shader_explicit_vertex_parameter"], set = "SPV_AMD_shader_explicit_vertex_parameter", id = 1) i16mat2x4 interpolateAtVertexAMD(i16mat2x4 interpolant, uint vertexIdx);
+spirv_instruction (extensions = ["SPV_AMD_shader_explicit_vertex_parameter"], set = "SPV_AMD_shader_explicit_vertex_parameter", id = 1) i16mat3x2 interpolateAtVertexAMD(i16mat3x2 interpolant, uint vertexIdx);
+spirv_instruction (extensions = ["SPV_AMD_shader_explicit_vertex_parameter"], set = "SPV_AMD_shader_explicit_vertex_parameter", id = 1) i16mat3x3 interpolateAtVertexAMD(i16mat3x3 interpolant, uint vertexIdx);
+spirv_instruction (extensions = ["SPV_AMD_shader_explicit_vertex_parameter"], set = "SPV_AMD_shader_explicit_vertex_parameter", id = 1) i16mat3x4 interpolateAtVertexAMD(i16mat3x4 interpolant, uint vertexIdx);
+spirv_instruction (extensions = ["SPV_AMD_shader_explicit_vertex_parameter"], set = "SPV_AMD_shader_explicit_vertex_parameter", id = 1) i16mat4x2 interpolateAtVertexAMD(i16mat4x2 interpolant, uint vertexIdx);
+spirv_instruction (extensions = ["SPV_AMD_shader_explicit_vertex_parameter"], set = "SPV_AMD_shader_explicit_vertex_parameter", id = 1) i16mat4x3 interpolateAtVertexAMD(i16mat4x3 interpolant, uint vertexIdx);
+spirv_instruction (extensions = ["SPV_AMD_shader_explicit_vertex_parameter"], set = "SPV_AMD_shader_explicit_vertex_parameter", id = 1) i16mat4x4 interpolateAtVertexAMD(i16mat4x4 interpolant, uint vertexIdx);
+#endif
+#endif

--- a/extensions/extension_headers/GL_AMD_shader_trinary_minmax.glsl
+++ b/extensions/extension_headers/GL_AMD_shader_trinary_minmax.glsl
@@ -1,0 +1,291 @@
+#define GL_AMD_shader_trinary_minmax 1
+
+#define SPV_FMIN3_AMD spirv_instruction (extensions = ["SPV_AMD_shader_trinary_minmax"], set = "SPV_AMD_shader_trinary_minmax", id = 1)
+#define SPV_UMIN3_AMD spirv_instruction (extensions = ["SPV_AMD_shader_trinary_minmax"], set = "SPV_AMD_shader_trinary_minmax", id = 2)
+#define SPV_SMIN3_AMD spirv_instruction (extensions = ["SPV_AMD_shader_trinary_minmax"], set = "SPV_AMD_shader_trinary_minmax", id = 3)
+#define SPV_FMAX3_AMD spirv_instruction (extensions = ["SPV_AMD_shader_trinary_minmax"], set = "SPV_AMD_shader_trinary_minmax", id = 4)
+#define SPV_UMAX3_AMD spirv_instruction (extensions = ["SPV_AMD_shader_trinary_minmax"], set = "SPV_AMD_shader_trinary_minmax", id = 5)
+#define SPV_SMAX3_AMD spirv_instruction (extensions = ["SPV_AMD_shader_trinary_minmax"], set = "SPV_AMD_shader_trinary_minmax", id = 6)
+#define SPV_FMID3_AMD spirv_instruction (extensions = ["SPV_AMD_shader_trinary_minmax"], set = "SPV_AMD_shader_trinary_minmax", id = 7)
+#define SPV_UMID3_AMD spirv_instruction (extensions = ["SPV_AMD_shader_trinary_minmax"], set = "SPV_AMD_shader_trinary_minmax", id = 8)
+#define SPV_SMID3_AMD spirv_instruction (extensions = ["SPV_AMD_shader_trinary_minmax"], set = "SPV_AMD_shader_trinary_minmax", id = 9)
+
+SPV_FMIN3_AMD float min3(float x, float y, float z);
+SPV_FMIN3_AMD vec2 min3(vec2 x, vec2 y, vec2 z);
+SPV_FMIN3_AMD vec3 min3(vec3 x, vec3 y, vec3 z);
+SPV_FMIN3_AMD vec4 min3(vec4 x, vec4 y, vec4 z);
+SPV_FMIN3_AMD mat2x2 min3(mat2x2 x, mat2x2 y, mat2x2 z);
+SPV_FMIN3_AMD mat2x3 min3(mat2x3 x, mat2x3 y, mat2x3 z);
+SPV_FMIN3_AMD mat2x4 min3(mat2x4 x, mat2x4 y, mat2x4 z);
+SPV_FMIN3_AMD mat3x2 min3(mat3x2 x, mat3x2 y, mat3x2 z);
+SPV_FMIN3_AMD mat3x3 min3(mat3x3 x, mat3x3 y, mat3x3 z);
+SPV_FMIN3_AMD mat3x4 min3(mat3x4 x, mat3x4 y, mat3x4 z);
+SPV_FMIN3_AMD mat4x2 min3(mat4x2 x, mat4x2 y, mat4x2 z);
+SPV_FMIN3_AMD mat4x3 min3(mat4x3 x, mat4x3 y, mat4x3 z);
+SPV_FMIN3_AMD mat4x4 min3(mat4x4 x, mat4x4 y, mat4x4 z);
+
+#if defined(GL_AMD_gpu_shader_half_float) || defined(GL_EXT_shader_explicit_arithmetic_types_float16)
+SPV_FMIN3_AMD float16_t min3(float16_t x, float16_t y, float16_t z);
+SPV_FMIN3_AMD f16vec2 min3(f16vec2 x, f16vec2 y, f16vec2 z);
+SPV_FMIN3_AMD f16vec3 min3(f16vec3 x, f16vec3 y, f16vec3 z);
+SPV_FMIN3_AMD f16vec4 min3(f16vec4 x, f16vec4 y, f16vec4 z);
+SPV_FMIN3_AMD f16mat2x2 min3(f16mat2x2 x, f16mat2x2 y, f16mat2x2 z);
+SPV_FMIN3_AMD f16mat2x3 min3(f16mat2x3 x, f16mat2x3 y, f16mat2x3 z);
+SPV_FMIN3_AMD f16mat2x4 min3(f16mat2x4 x, f16mat2x4 y, f16mat2x4 z);
+SPV_FMIN3_AMD f16mat3x2 min3(f16mat3x2 x, f16mat3x2 y, f16mat3x2 z);
+SPV_FMIN3_AMD f16mat3x3 min3(f16mat3x3 x, f16mat3x3 y, f16mat3x3 z);
+SPV_FMIN3_AMD f16mat3x4 min3(f16mat3x4 x, f16mat3x4 y, f16mat3x4 z);
+SPV_FMIN3_AMD f16mat4x2 min3(f16mat4x2 x, f16mat4x2 y, f16mat4x2 z);
+SPV_FMIN3_AMD f16mat4x3 min3(f16mat4x3 x, f16mat4x3 y, f16mat4x3 z);
+SPV_FMIN3_AMD f16mat4x4 min3(f16mat4x4 x, f16mat4x4 y, f16mat4x4 z);
+#endif
+
+SPV_UMIN3_AMD uint min3(uint x, uint y, uint z);
+SPV_UMIN3_AMD uvec2 min3(uvec2 x, uvec2 y, uvec2 z);
+SPV_UMIN3_AMD uvec3 min3(uvec3 x, uvec3 y, uvec3 z);
+SPV_UMIN3_AMD uvec4 min3(uvec4 x, uvec4 y, uvec4 z);
+SPV_UMIN3_AMD umat2x2 min3(umat2x2 x, umat2x2 y, umat2x2 z);
+SPV_UMIN3_AMD umat2x3 min3(umat2x3 x, umat2x3 y, umat2x3 z);
+SPV_UMIN3_AMD umat2x4 min3(umat2x4 x, umat2x4 y, umat2x4 z);
+SPV_UMIN3_AMD umat3x2 min3(umat3x2 x, umat3x2 y, umat3x2 z);
+SPV_UMIN3_AMD umat3x3 min3(umat3x3 x, umat3x3 y, umat3x3 z);
+SPV_UMIN3_AMD umat3x4 min3(umat3x4 x, umat3x4 y, umat3x4 z);
+SPV_UMIN3_AMD umat4x2 min3(umat4x2 x, umat4x2 y, umat4x2 z);
+SPV_UMIN3_AMD umat4x3 min3(umat4x3 x, umat4x3 y, umat4x3 z);
+SPV_UMIN3_AMD umat4x4 min3(umat4x4 x, umat4x4 y, umat4x4 z);
+
+#if defined(GL_EXT_shader_explicit_arithmetic_types_int16)
+SPV_UMIN3_AMD uint16_t min3(uint16_t x, uint16_t y, uint16_t z);
+SPV_UMIN3_AMD u16vec2 min3(u16vec2 x, u16vec2 y, u16vec2 z);
+SPV_UMIN3_AMD u16vec3 min3(u16vec3 x, u16vec3 y, u16vec3 z);
+SPV_UMIN3_AMD u16vec4 min3(u16vec4 x, u16vec4 y, u16vec4 z);
+SPV_UMIN3_AMD u16mat2x2 min3(u16mat2x2 x, u16mat2x2 y, u16mat2x2 z);
+SPV_UMIN3_AMD u16mat2x3 min3(u16mat2x3 x, u16mat2x3 y, u16mat2x3 z);
+SPV_UMIN3_AMD u16mat2x4 min3(u16mat2x4 x, u16mat2x4 y, u16mat2x4 z);
+SPV_UMIN3_AMD u16mat3x2 min3(u16mat3x2 x, u16mat3x2 y, u16mat3x2 z);
+SPV_UMIN3_AMD u16mat3x3 min3(u16mat3x3 x, u16mat3x3 y, u16mat3x3 z);
+SPV_UMIN3_AMD u16mat3x4 min3(u16mat3x4 x, u16mat3x4 y, u16mat3x4 z);
+SPV_UMIN3_AMD u16mat4x2 min3(u16mat4x2 x, u16mat4x2 y, u16mat4x2 z);
+SPV_UMIN3_AMD u16mat4x3 min3(u16mat4x3 x, u16mat4x3 y, u16mat4x3 z);
+SPV_UMIN3_AMD u16mat4x4 min3(u16mat4x4 x, u16mat4x4 y, u16mat4x4 z);
+#endif
+
+SPV_SMIN3_AMD int min3(int x, int y, int z);
+SPV_SMIN3_AMD ivec2 min3(ivec2 x, ivec2 y, ivec2 z);
+SPV_SMIN3_AMD ivec3 min3(ivec3 x, ivec3 y, ivec3 z);
+SPV_SMIN3_AMD ivec4 min3(ivec4 x, ivec4 y, ivec4 z);
+SPV_SMIN3_AMD imat2x2 min3(imat2x2 x, imat2x2 y, imat2x2 z);
+SPV_SMIN3_AMD imat2x3 min3(imat2x3 x, imat2x3 y, imat2x3 z);
+SPV_SMIN3_AMD imat2x4 min3(imat2x4 x, imat2x4 y, imat2x4 z);
+SPV_SMIN3_AMD imat3x2 min3(imat3x2 x, imat3x2 y, imat3x2 z);
+SPV_SMIN3_AMD imat3x3 min3(imat3x3 x, imat3x3 y, imat3x3 z);
+SPV_SMIN3_AMD imat3x4 min3(imat3x4 x, imat3x4 y, imat3x4 z);
+SPV_SMIN3_AMD imat4x2 min3(imat4x2 x, imat4x2 y, imat4x2 z);
+SPV_SMIN3_AMD imat4x3 min3(imat4x3 x, imat4x3 y, imat4x3 z);
+SPV_SMIN3_AMD imat4x4 min3(imat4x4 x, imat4x4 y, imat4x4 z);
+
+#if defined(GL_EXT_shader_explicit_arithmetic_types_int16)
+SPV_SMIN3_AMD int16_t min3(int16_t x, int16_t y, int16_t z);
+SPV_SMIN3_AMD i16vec2 min3(i16vec2 x, i16vec2 y, i16vec2 z);
+SPV_SMIN3_AMD i16vec3 min3(i16vec3 x, i16vec3 y, i16vec3 z);
+SPV_SMIN3_AMD i16vec4 min3(i16vec4 x, i16vec4 y, i16vec4 z);
+SPV_SMIN3_AMD i16mat2x2 min3(i16mat2x2 x, i16mat2x2 y, i16mat2x2 z);
+SPV_SMIN3_AMD i16mat2x3 min3(i16mat2x3 x, i16mat2x3 y, i16mat2x3 z);
+SPV_SMIN3_AMD i16mat2x4 min3(i16mat2x4 x, i16mat2x4 y, i16mat2x4 z);
+SPV_SMIN3_AMD i16mat3x2 min3(i16mat3x2 x, i16mat3x2 y, i16mat3x2 z);
+SPV_SMIN3_AMD i16mat3x3 min3(i16mat3x3 x, i16mat3x3 y, i16mat3x3 z);
+SPV_SMIN3_AMD i16mat3x4 min3(i16mat3x4 x, i16mat3x4 y, i16mat3x4 z);
+SPV_SMIN3_AMD i16mat4x2 min3(i16mat4x2 x, i16mat4x2 y, i16mat4x2 z);
+SPV_SMIN3_AMD i16mat4x3 min3(i16mat4x3 x, i16mat4x3 y, i16mat4x3 z);
+SPV_SMIN3_AMD i16mat4x4 min3(i16mat4x4 x, i16mat4x4 y, i16mat4x4 z);
+#endif
+
+SPV_FMAX3_AMD float max3(float x, float y, float z);
+SPV_FMAX3_AMD vec2 max3(vec2 x, vec2 y, vec2 z);
+SPV_FMAX3_AMD vec3 max3(vec3 x, vec3 y, vec3 z);
+SPV_FMAX3_AMD vec4 max3(vec4 x, vec4 y, vec4 z);
+SPV_FMAX3_AMD mat2x2 max3(mat2x2 x, mat2x2 y, mat2x2 z);
+SPV_FMAX3_AMD mat2x3 max3(mat2x3 x, mat2x3 y, mat2x3 z);
+SPV_FMAX3_AMD mat2x4 max3(mat2x4 x, mat2x4 y, mat2x4 z);
+SPV_FMAX3_AMD mat3x2 max3(mat3x2 x, mat3x2 y, mat3x2 z);
+SPV_FMAX3_AMD mat3x3 max3(mat3x3 x, mat3x3 y, mat3x3 z);
+SPV_FMAX3_AMD mat3x4 max3(mat3x4 x, mat3x4 y, mat3x4 z);
+SPV_FMAX3_AMD mat4x2 max3(mat4x2 x, mat4x2 y, mat4x2 z);
+SPV_FMAX3_AMD mat4x3 max3(mat4x3 x, mat4x3 y, mat4x3 z);
+SPV_FMAX3_AMD mat4x4 max3(mat4x4 x, mat4x4 y, mat4x4 z);
+
+#if defined(GL_AMD_gpu_shader_half_float) || defined(GL_EXT_shader_explicit_arithmetic_types_float16)
+SPV_FMAX3_AMD float16_t max3(float16_t x, float16_t y, float16_t z);
+SPV_FMAX3_AMD f16vec2 max3(f16vec2 x, f16vec2 y, f16vec2 z);
+SPV_FMAX3_AMD f16vec3 max3(f16vec3 x, f16vec3 y, f16vec3 z);
+SPV_FMAX3_AMD f16vec4 max3(f16vec4 x, f16vec4 y, f16vec4 z);
+SPV_FMAX3_AMD f16mat2x2 max3(f16mat2x2 x, f16mat2x2 y, f16mat2x2 z);
+SPV_FMAX3_AMD f16mat2x3 max3(f16mat2x3 x, f16mat2x3 y, f16mat2x3 z);
+SPV_FMAX3_AMD f16mat2x4 max3(f16mat2x4 x, f16mat2x4 y, f16mat2x4 z);
+SPV_FMAX3_AMD f16mat3x2 max3(f16mat3x2 x, f16mat3x2 y, f16mat3x2 z);
+SPV_FMAX3_AMD f16mat3x3 max3(f16mat3x3 x, f16mat3x3 y, f16mat3x3 z);
+SPV_FMAX3_AMD f16mat3x4 max3(f16mat3x4 x, f16mat3x4 y, f16mat3x4 z);
+SPV_FMAX3_AMD f16mat4x2 max3(f16mat4x2 x, f16mat4x2 y, f16mat4x2 z);
+SPV_FMAX3_AMD f16mat4x3 max3(f16mat4x3 x, f16mat4x3 y, f16mat4x3 z);
+SPV_FMAX3_AMD f16mat4x4 max3(f16mat4x4 x, f16mat4x4 y, f16mat4x4 z);
+#endif
+
+SPV_UMAX3_AMD uint max3(uint x, uint y, uint z);
+SPV_UMAX3_AMD uvec2 max3(uvec2 x, uvec2 y, uvec2 z);
+SPV_UMAX3_AMD uvec3 max3(uvec3 x, uvec3 y, uvec3 z);
+SPV_UMAX3_AMD uvec4 max3(uvec4 x, uvec4 y, uvec4 z);
+SPV_UMAX3_AMD umat2x2 max3(umat2x2 x, umat2x2 y, umat2x2 z);
+SPV_UMAX3_AMD umat2x3 max3(umat2x3 x, umat2x3 y, umat2x3 z);
+SPV_UMAX3_AMD umat2x4 max3(umat2x4 x, umat2x4 y, umat2x4 z);
+SPV_UMAX3_AMD umat3x2 max3(umat3x2 x, umat3x2 y, umat3x2 z);
+SPV_UMAX3_AMD umat3x3 max3(umat3x3 x, umat3x3 y, umat3x3 z);
+SPV_UMAX3_AMD umat3x4 max3(umat3x4 x, umat3x4 y, umat3x4 z);
+SPV_UMAX3_AMD umat4x2 max3(umat4x2 x, umat4x2 y, umat4x2 z);
+SPV_UMAX3_AMD umat4x3 max3(umat4x3 x, umat4x3 y, umat4x3 z);
+SPV_UMAX3_AMD umat4x4 max3(umat4x4 x, umat4x4 y, umat4x4 z);
+
+#if defined(GL_EXT_shader_explicit_arithmetic_types_int16)
+SPV_UMAX3_AMD uint16_t max3(uint16_t x, uint16_t y, uint16_t z);
+SPV_UMAX3_AMD u16vec2 max3(u16vec2 x, u16vec2 y, u16vec2 z);
+SPV_UMAX3_AMD u16vec3 max3(u16vec3 x, u16vec3 y, u16vec3 z);
+SPV_UMAX3_AMD u16vec4 max3(u16vec4 x, u16vec4 y, u16vec4 z);
+SPV_UMAX3_AMD u16mat2x2 max3(u16mat2x2 x, u16mat2x2 y, u16mat2x2 z);
+SPV_UMAX3_AMD u16mat2x3 max3(u16mat2x3 x, u16mat2x3 y, u16mat2x3 z);
+SPV_UMAX3_AMD u16mat2x4 max3(u16mat2x4 x, u16mat2x4 y, u16mat2x4 z);
+SPV_UMAX3_AMD u16mat3x2 max3(u16mat3x2 x, u16mat3x2 y, u16mat3x2 z);
+SPV_UMAX3_AMD u16mat3x3 max3(u16mat3x3 x, u16mat3x3 y, u16mat3x3 z);
+SPV_UMAX3_AMD u16mat3x4 max3(u16mat3x4 x, u16mat3x4 y, u16mat3x4 z);
+SPV_UMAX3_AMD u16mat4x2 max3(u16mat4x2 x, u16mat4x2 y, u16mat4x2 z);
+SPV_UMAX3_AMD u16mat4x3 max3(u16mat4x3 x, u16mat4x3 y, u16mat4x3 z);
+SPV_UMAX3_AMD u16mat4x4 max3(u16mat4x4 x, u16mat4x4 y, u16mat4x4 z);
+#endif
+
+SPV_SMAX3_AMD int max3(int x, int y, int z);
+SPV_SMAX3_AMD ivec2 max3(ivec2 x, ivec2 y, ivec2 z);
+SPV_SMAX3_AMD ivec3 max3(ivec3 x, ivec3 y, ivec3 z);
+SPV_SMAX3_AMD ivec4 max3(ivec4 x, ivec4 y, ivec4 z);
+SPV_SMAX3_AMD imat2x2 max3(imat2x2 x, imat2x2 y, imat2x2 z);
+SPV_SMAX3_AMD imat2x3 max3(imat2x3 x, imat2x3 y, imat2x3 z);
+SPV_SMAX3_AMD imat2x4 max3(imat2x4 x, imat2x4 y, imat2x4 z);
+SPV_SMAX3_AMD imat3x2 max3(imat3x2 x, imat3x2 y, imat3x2 z);
+SPV_SMAX3_AMD imat3x3 max3(imat3x3 x, imat3x3 y, imat3x3 z);
+SPV_SMAX3_AMD imat3x4 max3(imat3x4 x, imat3x4 y, imat3x4 z);
+SPV_SMAX3_AMD imat4x2 max3(imat4x2 x, imat4x2 y, imat4x2 z);
+SPV_SMAX3_AMD imat4x3 max3(imat4x3 x, imat4x3 y, imat4x3 z);
+SPV_SMAX3_AMD imat4x4 max3(imat4x4 x, imat4x4 y, imat4x4 z);
+
+#if defined(GL_EXT_shader_explicit_arithmetic_types_int16)
+SPV_SMAX3_AMD int16_t max3(int16_t x, int16_t y, int16_t z);
+SPV_SMAX3_AMD i16vec2 max3(i16vec2 x, i16vec2 y, i16vec2 z);
+SPV_SMAX3_AMD i16vec3 max3(i16vec3 x, i16vec3 y, i16vec3 z);
+SPV_SMAX3_AMD i16vec4 max3(i16vec4 x, i16vec4 y, i16vec4 z);
+SPV_SMAX3_AMD i16mat2x2 max3(i16mat2x2 x, i16mat2x2 y, i16mat2x2 z);
+SPV_SMAX3_AMD i16mat2x3 max3(i16mat2x3 x, i16mat2x3 y, i16mat2x3 z);
+SPV_SMAX3_AMD i16mat2x4 max3(i16mat2x4 x, i16mat2x4 y, i16mat2x4 z);
+SPV_SMAX3_AMD i16mat3x2 max3(i16mat3x2 x, i16mat3x2 y, i16mat3x2 z);
+SPV_SMAX3_AMD i16mat3x3 max3(i16mat3x3 x, i16mat3x3 y, i16mat3x3 z);
+SPV_SMAX3_AMD i16mat3x4 max3(i16mat3x4 x, i16mat3x4 y, i16mat3x4 z);
+SPV_SMAX3_AMD i16mat4x2 max3(i16mat4x2 x, i16mat4x2 y, i16mat4x2 z);
+SPV_SMAX3_AMD i16mat4x3 max3(i16mat4x3 x, i16mat4x3 y, i16mat4x3 z);
+SPV_SMAX3_AMD i16mat4x4 max3(i16mat4x4 x, i16mat4x4 y, i16mat4x4 z);
+#endif
+
+SPV_FMID3_AMD float mid3(float x, float y, float z);
+SPV_FMID3_AMD vec2 mid3(vec2 x, vec2 y, vec2 z);
+SPV_FMID3_AMD vec3 mid3(vec3 x, vec3 y, vec3 z);
+SPV_FMID3_AMD vec4 mid3(vec4 x, vec4 y, vec4 z);
+SPV_FMID3_AMD mat2x2 mid3(mat2x2 x, mat2x2 y, mat2x2 z);
+SPV_FMID3_AMD mat2x3 mid3(mat2x3 x, mat2x3 y, mat2x3 z);
+SPV_FMID3_AMD mat2x4 mid3(mat2x4 x, mat2x4 y, mat2x4 z);
+SPV_FMID3_AMD mat3x2 mid3(mat3x2 x, mat3x2 y, mat3x2 z);
+SPV_FMID3_AMD mat3x3 mid3(mat3x3 x, mat3x3 y, mat3x3 z);
+SPV_FMID3_AMD mat3x4 mid3(mat3x4 x, mat3x4 y, mat3x4 z);
+SPV_FMID3_AMD mat4x2 mid3(mat4x2 x, mat4x2 y, mat4x2 z);
+SPV_FMID3_AMD mat4x3 mid3(mat4x3 x, mat4x3 y, mat4x3 z);
+SPV_FMID3_AMD mat4x4 mid3(mat4x4 x, mat4x4 y, mat4x4 z);
+
+#if defined(GL_AMD_gpu_shader_half_float) || defined(GL_EXT_shader_explicit_arithmetic_types_float16)
+SPV_FMID3_AMD float16_t mid3(float16_t x, float16_t y, float16_t z);
+SPV_FMID3_AMD f16vec2 mid3(f16vec2 x, f16vec2 y, f16vec2 z);
+SPV_FMID3_AMD f16vec3 mid3(f16vec3 x, f16vec3 y, f16vec3 z);
+SPV_FMID3_AMD f16vec4 mid3(f16vec4 x, f16vec4 y, f16vec4 z);
+SPV_FMID3_AMD f16mat2x2 mid3(f16mat2x2 x, f16mat2x2 y, f16mat2x2 z);
+SPV_FMID3_AMD f16mat2x3 mid3(f16mat2x3 x, f16mat2x3 y, f16mat2x3 z);
+SPV_FMID3_AMD f16mat2x4 mid3(f16mat2x4 x, f16mat2x4 y, f16mat2x4 z);
+SPV_FMID3_AMD f16mat3x2 mid3(f16mat3x2 x, f16mat3x2 y, f16mat3x2 z);
+SPV_FMID3_AMD f16mat3x3 mid3(f16mat3x3 x, f16mat3x3 y, f16mat3x3 z);
+SPV_FMID3_AMD f16mat3x4 mid3(f16mat3x4 x, f16mat3x4 y, f16mat3x4 z);
+SPV_FMID3_AMD f16mat4x2 mid3(f16mat4x2 x, f16mat4x2 y, f16mat4x2 z);
+SPV_FMID3_AMD f16mat4x3 mid3(f16mat4x3 x, f16mat4x3 y, f16mat4x3 z);
+SPV_FMID3_AMD f16mat4x4 mid3(f16mat4x4 x, f16mat4x4 y, f16mat4x4 z);
+#endif
+
+SPV_UMID3_AMD uint mid3(uint x, uint y, uint z);
+SPV_UMID3_AMD uvec2 mid3(uvec2 x, uvec2 y, uvec2 z);
+SPV_UMID3_AMD uvec3 mid3(uvec3 x, uvec3 y, uvec3 z);
+SPV_UMID3_AMD uvec4 mid3(uvec4 x, uvec4 y, uvec4 z);
+SPV_UMID3_AMD umat2x2 mid3(umat2x2 x, umat2x2 y, umat2x2 z);
+SPV_UMID3_AMD umat2x3 mid3(umat2x3 x, umat2x3 y, umat2x3 z);
+SPV_UMID3_AMD umat2x4 mid3(umat2x4 x, umat2x4 y, umat2x4 z);
+SPV_UMID3_AMD umat3x2 mid3(umat3x2 x, umat3x2 y, umat3x2 z);
+SPV_UMID3_AMD umat3x3 mid3(umat3x3 x, umat3x3 y, umat3x3 z);
+SPV_UMID3_AMD umat3x4 mid3(umat3x4 x, umat3x4 y, umat3x4 z);
+SPV_UMID3_AMD umat4x2 mid3(umat4x2 x, umat4x2 y, umat4x2 z);
+SPV_UMID3_AMD umat4x3 mid3(umat4x3 x, umat4x3 y, umat4x3 z);
+SPV_UMID3_AMD umat4x4 mid3(umat4x4 x, umat4x4 y, umat4x4 z);
+
+#if defined(GL_EXT_shader_explicit_arithmetic_types_int16)
+SPV_UMID3_AMD uint16_t mid3(uint16_t x, uint16_t y, uint16_t z);
+SPV_UMID3_AMD u16vec2 mid3(u16vec2 x, u16vec2 y, u16vec2 z);
+SPV_UMID3_AMD u16vec3 mid3(u16vec3 x, u16vec3 y, u16vec3 z);
+SPV_UMID3_AMD u16vec4 mid3(u16vec4 x, u16vec4 y, u16vec4 z);
+SPV_UMID3_AMD u16mat2x2 mid3(u16mat2x2 x, u16mat2x2 y, u16mat2x2 z);
+SPV_UMID3_AMD u16mat2x3 mid3(u16mat2x3 x, u16mat2x3 y, u16mat2x3 z);
+SPV_UMID3_AMD u16mat2x4 mid3(u16mat2x4 x, u16mat2x4 y, u16mat2x4 z);
+SPV_UMID3_AMD u16mat3x2 mid3(u16mat3x2 x, u16mat3x2 y, u16mat3x2 z);
+SPV_UMID3_AMD u16mat3x3 mid3(u16mat3x3 x, u16mat3x3 y, u16mat3x3 z);
+SPV_UMID3_AMD u16mat3x4 mid3(u16mat3x4 x, u16mat3x4 y, u16mat3x4 z);
+SPV_UMID3_AMD u16mat4x2 mid3(u16mat4x2 x, u16mat4x2 y, u16mat4x2 z);
+SPV_UMID3_AMD u16mat4x3 mid3(u16mat4x3 x, u16mat4x3 y, u16mat4x3 z);
+SPV_UMID3_AMD u16mat4x4 mid3(u16mat4x4 x, u16mat4x4 y, u16mat4x4 z);
+#endif
+
+SPV_SMID3_AMD int mid3(int x, int y, int z);
+SPV_SMID3_AMD ivec2 mid3(ivec2 x, ivec2 y, ivec2 z);
+SPV_SMID3_AMD ivec3 mid3(ivec3 x, ivec3 y, ivec3 z);
+SPV_SMID3_AMD ivec4 mid3(ivec4 x, ivec4 y, ivec4 z);
+SPV_SMID3_AMD imat2x2 mid3(imat2x2 x, imat2x2 y, imat2x2 z);
+SPV_SMID3_AMD imat2x3 mid3(imat2x3 x, imat2x3 y, imat2x3 z);
+SPV_SMID3_AMD imat2x4 mid3(imat2x4 x, imat2x4 y, imat2x4 z);
+SPV_SMID3_AMD imat3x2 mid3(imat3x2 x, imat3x2 y, imat3x2 z);
+SPV_SMID3_AMD imat3x3 mid3(imat3x3 x, imat3x3 y, imat3x3 z);
+SPV_SMID3_AMD imat3x4 mid3(imat3x4 x, imat3x4 y, imat3x4 z);
+SPV_SMID3_AMD imat4x2 mid3(imat4x2 x, imat4x2 y, imat4x2 z);
+SPV_SMID3_AMD imat4x3 mid3(imat4x3 x, imat4x3 y, imat4x3 z);
+SPV_SMID3_AMD imat4x4 mid3(imat4x4 x, imat4x4 y, imat4x4 z);
+
+#if defined(GL_EXT_shader_explicit_arithmetic_types_int16)
+SPV_SMID3_AMD int16_t mid3(int16_t x, int16_t y, int16_t z);
+SPV_SMID3_AMD i16vec2 mid3(i16vec2 x, i16vec2 y, i16vec2 z);
+SPV_SMID3_AMD i16vec3 mid3(i16vec3 x, i16vec3 y, i16vec3 z);
+SPV_SMID3_AMD i16vec4 mid3(i16vec4 x, i16vec4 y, i16vec4 z);
+SPV_SMID3_AMD i16mat2x2 mid3(i16mat2x2 x, i16mat2x2 y, i16mat2x2 z);
+SPV_SMID3_AMD i16mat2x3 mid3(i16mat2x3 x, i16mat2x3 y, i16mat2x3 z);
+SPV_SMID3_AMD i16mat2x4 mid3(i16mat2x4 x, i16mat2x4 y, i16mat2x4 z);
+SPV_SMID3_AMD i16mat3x2 mid3(i16mat3x2 x, i16mat3x2 y, i16mat3x2 z);
+SPV_SMID3_AMD i16mat3x3 mid3(i16mat3x3 x, i16mat3x3 y, i16mat3x3 z);
+SPV_SMID3_AMD i16mat3x4 mid3(i16mat3x4 x, i16mat3x4 y, i16mat3x4 z);
+SPV_SMID3_AMD i16mat4x2 mid3(i16mat4x2 x, i16mat4x2 y, i16mat4x2 z);
+SPV_SMID3_AMD i16mat4x3 mid3(i16mat4x3 x, i16mat4x3 y, i16mat4x3 z);
+SPV_SMID3_AMD i16mat4x4 mid3(i16mat4x4 x, i16mat4x4 y, i16mat4x4 z);
+#endif
+
+#undef SPV_FMIN3_AMD
+#undef SPV_UMIN3_AMD
+#undef SPV_SMIN3_AMD
+#undef SPV_FMAX3_AMD
+#undef SPV_UMAX3_AMD
+#undef SPV_SMAX3_AMD
+#undef SPV_FMID3_AMD
+#undef SPV_UMID3_AMD
+#undef SPV_SMID3_AMD

--- a/extensions/extension_headers/GL_ARB_shader_stencil_export.glsl
+++ b/extensions/extension_headers/GL_ARB_shader_stencil_export.glsl
@@ -1,0 +1,8 @@
+#if defined(GL_FRAGMENT_SHADER)
+#define GL_ARB_shader_stencil_export 1
+
+spirv_execution_mode(extensions = ["SPV_EXT_shader_stencil_export"], capabilities = [5013], 5027);     
+
+spirv_decorate (extensions = ["SPV_EXT_shader_stencil_export"], capabilities = [5013], 11, 5014)        
+out int gl_FragStencilRefARB; 
+#endif

--- a/extensions/extension_headers/GL_EXT_ray_flags_primitive_culling.glsl
+++ b/extensions/extension_headers/GL_EXT_ray_flags_primitive_culling.glsl
@@ -1,0 +1,4 @@
+#define GL_EXT_ray_flags_primitive_culling 1
+
+const uint gl_RayFlagsSkipTrianglesEXT = 256U;
+const uint gl_RayFlagsSkipAABBEXT = 512U;

--- a/extensions/extension_headers/GL_EXT_ray_query.glsl
+++ b/extensions/extension_headers/GL_EXT_ray_query.glsl
@@ -1,0 +1,145 @@
+#define GL_EXT_ray_query 1
+
+#define rayQueryEXT spirv_type (extensions = ["SPV_KHR_ray_query"], capabilities = [4472], id = 4472)
+
+#ifndef GL_EXT_ray_tracing
+#define accelerationStructureEXT spirv_type (extensions = ["SPV_KHR_ray_query"], capabilities = [4472], id = 5341)
+
+const uint gl_RayFlagsNoneEXT = 0U;
+const uint gl_RayFlagsOpaqueEXT = 1U;
+const uint gl_RayFlagsNoOpaqueEXT = 2U;
+const uint gl_RayFlagsTerminateOnFirstHitEXT = 4U;
+const uint gl_RayFlagsSkipClosestHitShaderEXT = 8U;
+const uint gl_RayFlagsCullBackFacingTrianglesEXT = 16U;
+const uint gl_RayFlagsCullFrontFacingTrianglesEXT = 32U;
+const uint gl_RayFlagsCullOpaqueEXT = 64U;
+const uint gl_RayFlagsCullNoOpaqueEXT = 128U;
+#endif
+
+const uint gl_RayQueryCommittedIntersectionNoneEXT = 0U;
+const uint gl_RayQueryCommittedIntersectionTriangleEXT = 1U;
+const uint gl_RayQueryCommittedIntersectionGeneratedEXT = 2U;
+
+const uint gl_RayQueryCandidateIntersectionTriangleEXT = 0U;
+const uint gl_RayQueryCandidateIntersectionAABBEXT = 1U;
+
+spirv_instruction (extensions = ["SPV_KHR_ray_query"], capabilities = [4471,4478], id = 4473) 
+void rayQueryInitializeEXT(spirv_by_reference rayQueryEXT rayQuery, accelerationStructureEXT topLevel, uint rayFlags, uint cullMask, vec3 origin, float tMin, vec3 direction, float tMax);
+
+spirv_instruction (extensions = ["SPV_KHR_ray_query"], capabilities = [4472], id = 4477) 
+bool rayQueryProceedEXT(spirv_by_reference rayQueryEXT q);
+
+spirv_instruction (extensions = ["SPV_KHR_ray_query"], capabilities = [4472], id = 4474) 
+void rayQueryTerminateEXT(spirv_by_reference rayQueryEXT q);
+
+spirv_instruction (extensions = ["SPV_KHR_ray_query"], capabilities = [4472], id = 4475) 
+void rayQueryGenerateIntersectionEXT(spirv_by_reference rayQueryEXT q, float tHit);
+
+spirv_instruction (extensions = ["SPV_KHR_ray_query"], capabilities = [4472], id = 4476) 
+void rayQueryConfirmIntersectionEXT(spirv_by_reference rayQueryEXT q);
+
+uint rayQueryGetIntersectionTypeEXT(spirv_by_reference rayQueryEXT q, bool committed) {
+    spirv_instruction (extensions = ["SPV_KHR_ray_query"], capabilities = [4472], id = 4479) 
+    uint rayQueryGetIntersectionTypeEXT_internal(spirv_by_reference rayQueryEXT q, uint committed);
+
+    return rayQueryGetIntersectionTypeEXT_internal(q, committed ? 1 : 0);
+}
+
+spirv_instruction (extensions = ["SPV_KHR_ray_query"], capabilities = [4472], id = 6016) 
+float rayQueryGetRayTMinEXT(spirv_by_reference rayQueryEXT q);
+
+spirv_instruction (extensions = ["SPV_KHR_ray_query"], capabilities = [4472], id = 6016) 
+uint rayQueryGetRayFlagsEXT(spirv_by_reference rayQueryEXT q);
+
+spirv_instruction (extensions = ["SPV_KHR_ray_query"], capabilities = [4472], id = 6030) 
+vec3 rayQueryGetWorldRayOriginEXT(spirv_by_reference rayQueryEXT q);
+
+spirv_instruction (extensions = ["SPV_KHR_ray_query"], capabilities = [4472], id = 6029) 
+vec3 rayQueryGetWorldRayDirectionEXT(spirv_by_reference rayQueryEXT q);
+
+float rayQueryGetIntersectionTEXT(spirv_by_reference rayQueryEXT q, bool committed) {
+    spirv_instruction (extensions = ["SPV_KHR_ray_query"], capabilities = [4472], id = 6018) 
+    float rayQueryGetIntersectionTEXT_internal(spirv_by_reference rayQueryEXT q, uint committed);
+
+    return rayQueryGetIntersectionTEXT_internal(q, committed ? 1 : 0);
+}
+
+int rayQueryGetIntersectionInstanceCustomIndexEXT(spirv_by_reference rayQueryEXT q, bool committed) {
+    spirv_instruction (extensions = ["SPV_KHR_ray_query"], capabilities = [4472], id = 6019) 
+    int rayQueryGetIntersectionInstanceCustomIndexEXT_internal(spirv_by_reference rayQueryEXT q, uint committed);
+
+    return rayQueryGetIntersectionInstanceCustomIndexEXT_internal(q, committed ? 1 : 0);
+}
+
+int rayQueryGetIntersectionInstanceIdEXT(spirv_by_reference rayQueryEXT q, bool committed) {
+    spirv_instruction (extensions = ["SPV_KHR_ray_query"], capabilities = [4472], id = 6020) 
+    int rayQueryGetIntersectionInstanceIdEXT_internal(spirv_by_reference rayQueryEXT q, uint committed);
+
+    return rayQueryGetIntersectionInstanceIdEXT_internal(q, committed ? 1 : 0);
+}
+
+uint rayQueryGetIntersectionInstanceShaderBindingTableRecordOffsetEXT(spirv_by_reference rayQueryEXT q, bool committed) {
+    spirv_instruction (extensions = ["SPV_KHR_ray_query"], capabilities = [4472], id = 6021) 
+    uint rayQueryGetIntersectionInstanceShaderBindingTableRecordOffsetEXT_internal(spirv_by_reference rayQueryEXT q, uint committed);
+
+    return rayQueryGetIntersectionInstanceShaderBindingTableRecordOffsetEXT_internal(q, committed ? 1 : 0);
+}
+
+int rayQueryGetIntersectionGeometryIndexEXT(spirv_by_reference rayQueryEXT q, bool committed) {
+    spirv_instruction (extensions = ["SPV_KHR_ray_query"], capabilities = [4472], id = 6022) 
+    int rayQueryGetIntersectionGeometryIndexEXT_internal(spirv_by_reference rayQueryEXT q, uint committed);
+
+    return rayQueryGetIntersectionGeometryIndexEXT_internal(q, committed ? 1 : 0);
+}
+
+int rayQueryGetIntersectionPrimitiveIndexEXT(spirv_by_reference rayQueryEXT q, bool committed) {
+    spirv_instruction (extensions = ["SPV_KHR_ray_query"], capabilities = [4472], id = 6023) 
+    int rayQueryGetIntersectionPrimitiveIndexEXT_internal(spirv_by_reference rayQueryEXT q, uint committed);
+
+    return rayQueryGetIntersectionPrimitiveIndexEXT_internal(q, committed ? 1 : 0);
+}
+
+vec2 rayQueryGetIntersectionBarycentricsEXT(spirv_by_reference rayQueryEXT q, bool committed) {
+    spirv_instruction (extensions = ["SPV_KHR_ray_query"], capabilities = [4472], id = 6024) 
+    vec2 rayQueryGetIntersectionBarycentricsEXT_internal(spirv_by_reference rayQueryEXT q, uint committed);
+
+    return rayQueryGetIntersectionBarycentricsEXT_internal(q, committed ? 1 : 0);
+}
+
+bool rayQueryGetIntersectionFrontFaceEXT(spirv_by_reference rayQueryEXT q, bool committed) {
+    spirv_instruction (extensions = ["SPV_KHR_ray_query"], capabilities = [4472], id = 6025) 
+    bool rayQueryGetIntersectionFrontFaceEXT_internal(spirv_by_reference rayQueryEXT q, uint committed);
+
+    return rayQueryGetIntersectionFrontFaceEXT_internal(q, committed ? 1 : 0);
+}
+
+spirv_instruction (extensions = ["SPV_KHR_ray_query"], capabilities = [4472], id = 6026) 
+bool rayQueryGetIntersectionCandidateAABBOpaqueEXT(spirv_by_reference rayQueryEXT q);
+
+vec3 rayQueryGetIntersectionObjectRayDirectionEXT(spirv_by_reference rayQueryEXT q, bool committed) {
+    spirv_instruction (extensions = ["SPV_KHR_ray_query"], capabilities = [4472], id = 6027) 
+    vec3 rayQueryGetIntersectionObjectRayDirectionEXT_internal(spirv_by_reference rayQueryEXT q, uint committed);
+
+    return rayQueryGetIntersectionObjectRayDirectionEXT_internal(q, committed ? 1 : 0);
+}
+
+vec3 rayQueryGetIntersectionObjectRayOriginEXT(spirv_by_reference rayQueryEXT q, bool committed) {
+    spirv_instruction (extensions = ["SPV_KHR_ray_query"], capabilities = [4472], id = 6028) 
+    vec3 rayQueryGetIntersectionObjectRayOriginEXT_internal(spirv_by_reference rayQueryEXT q, uint committed);
+
+    return rayQueryGetIntersectionObjectRayOriginEXT_internal(q, committed ? 1 : 0);
+}
+
+mat4x3 rayQueryGetIntersectionObjectToWorldEXT(spirv_by_reference rayQueryEXT q, bool committed) {
+    spirv_instruction (extensions = ["SPV_KHR_ray_query"], capabilities = [4472], id = 6031) 
+    mat4x3 rayQueryGetIntersectionObjectToWorldEXT_internal(spirv_by_reference rayQueryEXT q, uint committed);
+
+    return rayQueryGetIntersectionObjectToWorldEXT_internal(q, committed ? 1 : 0);
+}
+
+mat4x3 rayQueryGetIntersectionWorldToObjectEXT(spirv_by_reference rayQueryEXT q, bool committed) {
+    spirv_instruction (extensions = ["SPV_KHR_ray_query"], capabilities = [4472], id = 6032) 
+    mat4x3 rayQueryGetIntersectionWorldToObjectEXT_internal(spirv_by_reference rayQueryEXT q, uint committed);
+
+    return rayQueryGetIntersectionWorldToObjectEXT_internal(q, committed ? 1 : 0);
+}

--- a/extensions/extension_headers/GL_EXT_ray_tracing.glsl
+++ b/extensions/extension_headers/GL_EXT_ray_tracing.glsl
@@ -1,0 +1,135 @@
+#if defined(GL_RAY_GENERATION_SHADER_EXT) || defined(GL_INTERSECTION_SHADER_EXT) || defined(GL_ANY_HIT_SHADER_EXT) || defined(GL_CLOSEST_HIT_SHADER_EXT) || defined(GL_MISS_SHADER_EXT) || defined(GL_CALLABLE_SHADER_EXT)
+#define GL_EXT_ray_tracing 1
+
+spirv_extension ("SPV_KHR_ray_tracing")
+spirv_capability (5353) 
+
+#ifndef GL_EXT_ray_query
+#define accelerationStructureEXT spirv_type (extensions = ["SPV_KHR_ray_tracing"], capabilities = [5353], id = 5341)
+#endif
+
+#if defined(GL_RAY_GENERATION_SHADER_EXT) || defined(GL_CLOSEST_HIT_SHADER_EXT) || defined(GL_MISS_SHADER_EXT)
+#define rayPayloadEXT spirv_storage_class (extensions = ["SPV_KHR_ray_tracing"], capabilities = [5353], 5338)
+#endif
+#if defined(GL_ANY_HIT_SHADER_EXT) || defined(GL_CLOSEST_HIT_SHADER_EXT) || defined(GL_MISS_SHADER_EXT)
+#define rayPayloadInEXT spirv_storage_class (extensions = ["SPV_KHR_ray_tracing"], capabilities = [5353], 5342)
+#endif
+#if defined(GL_ANY_HIT_SHADER_EXT) || defined(GL_CLOSEST_HIT_SHADER_EXT) || defined(GL_INTERSECTION_SHADER_EXT)
+#define hitAttributeEXT spirv_storage_class (extensions = ["SPV_KHR_ray_tracing"], capabilities = [5353], 5339)
+#endif
+#if defined(GL_RAY_GENERATION_SHADER_EXT) || defined(GL_CLOSEST_HIT_SHADER_EXT) || defined(GL_MISS_SHADER_EXT) || defined((GL_CALLABLE_SHADER)
+#define callableDataEXT spirv_storage_class (extensions = ["SPV_KHR_ray_tracing"], capabilities = [5353], 5328)
+#endif
+#ifdef(GL_CALLABLE_SHADER)
+#define callableDataInEXT spirv_storage_class (extensions = ["SPV_KHR_ray_tracing"], capabilities = [5353], 5329)
+#endif
+#define shaderRecordEXT spirv_storage_class (extensions = ["SPV_KHR_ray_tracing"], capabilities = [5353], 5343)
+
+#ifndef GL_EXT_ray_query
+const uint gl_RayFlagsNoneEXT = 0U;
+const uint gl_RayFlagsOpaqueEXT = 1U;
+const uint gl_RayFlagsNoOpaqueEXT = 2U;
+const uint gl_RayFlagsTerminateOnFirstHitEXT = 4U;
+const uint gl_RayFlagsSkipClosestHitShaderEXT = 8U;
+const uint gl_RayFlagsCullBackFacingTrianglesEXT = 16U;
+const uint gl_RayFlagsCullFrontFacingTrianglesEXT = 32U;
+const uint gl_RayFlagsCullOpaqueEXT = 64U;
+const uint gl_RayFlagsCullNoOpaqueEXT = 128U;
+#endif
+
+const uint gl_HitKindFrontFacingTriangleEXT = 0xFEU;
+const uint gl_HitKindBackFacingTriangleEXT = 0xFFU;
+
+const int gl_ScopeShaderCallEXT = 6;
+
+
+spirv_decorate (extensions = ["SPV_KHR_ray_tracing"], capabilities = [5353], 11, 5319) 
+in uvec3 gl_LaunchIDEXT;
+spirv_decorate (extensions = ["SPV_KHR_ray_tracing"], capabilities = [5353], 11, 5320) 
+in uvec3 gl_LaunchSizeEXT;
+
+#if defined(GL_INTERSECTION_SHADER_EXT) || defined(GL_ANY_HIT_SHADER_EXT) || defined(GL_CLOSEST_HIT_SHADER_EXT)
+
+spirv_decorate (extensions = ["SPV_KHR_ray_tracing"], capabilities = [5353], 11, 7) 
+in int gl_PrimitiveID;
+spirv_decorate (extensions = ["SPV_KHR_ray_tracing"], capabilities = [5353], 11, 6) 
+in int gl_InstanceID;
+spirv_decorate (extensions = ["SPV_KHR_ray_tracing"], capabilities = [5353], 11, 5327) 
+in int gl_InstanceCustomIndexEXT;
+spirv_decorate (extensions = ["SPV_KHR_ray_tracing"], capabilities = [5353], 11, 5352) 
+in int gl_GeometryIndexEXT;
+#endif
+
+#if defined(GL_INTERSECTION_SHADER_EXT) || defined(GL_ANY_HIT_SHADER_EXT) || defined(GL_CLOSEST_HIT_SHADER_EXT) || defined(GL_MISS_SHADER_EXT)
+
+spirv_decorate (extensions = ["SPV_KHR_ray_tracing"], capabilities = [5353], 11, 5321) 
+in vec3 gl_WorldRayOriginEXT;
+spirv_decorate (extensions = ["SPV_KHR_ray_tracing"], capabilities = [5353], 11, 5322) 
+in vec3 gl_WorldRayDirectionEXT;
+spirv_decorate (extensions = ["SPV_KHR_ray_tracing"], capabilities = [5353], 11, 5323) 
+in vec3 gl_ObjectRayOriginEXT;
+spirv_decorate (extensions = ["SPV_KHR_ray_tracing"], capabilities = [5353], 11, 5324) 
+in vec3 gl_ObjectRayDirectionEXT;
+
+
+spirv_decorate (extensions = ["SPV_KHR_ray_tracing"], capabilities = [5353], 11, 5325) 
+in float gl_RayTminEXT;
+spirv_decorate (extensions = ["SPV_KHR_ray_tracing"], capabilities = [5353], 11, 5326) 
+in float gl_RayTmaxEXT;
+spirv_decorate (extensions = ["SPV_KHR_ray_tracing"], capabilities = [5353], 11, 5351) 
+in uint gl_IncomingRayFlagsEXT;
+#endif
+
+#if defined(GL_ANY_HIT_SHADER_EXT) || defined(GL_CLOSEST_HIT_SHADER_EXT)
+
+spirv_decorate (extensions = ["SPV_KHR_ray_tracing"], capabilities = [5353], 11, 5326) 
+in float gl_HitTEXT;
+spirv_decorate (extensions = ["SPV_KHR_ray_tracing"], capabilities = [5353], 11, 5333) 
+in uint gl_HitKindEXT;
+#endif
+
+#if defined(GL_INTERSECTION_SHADER_EXT) || defined(GL_ANY_HIT_SHADER_EXT) || defined(GL_CLOSEST_HIT_SHADER_EXT)
+
+spirv_decorate (extensions = ["SPV_KHR_ray_tracing"], capabilities = [5353], 11, 5330) 
+in mat4x3 gl_ObjectToWorldEXT;
+#define gl_ObjectToWorld3x4EXT (transpose(gl_ObjectToWorldEXT))
+spirv_decorate (extensions = ["SPV_KHR_ray_tracing"], capabilities = [5353], 11, 5331) 
+in mat4x3 gl_WorldToObjectEXT;
+#define gl_WorldToObject3x4EXT (transpose(gl_WorldToObjectEXT))
+#endif
+
+#if defined(GL_RAY_GENERATION_SHADER_EXT) || defined(GL_CLOSEST_HIT_SHADER_EXT) || defined(GL_MISS_SHADER_EXT)
+spirv_instruction (extensions = ["SPV_KHR_ray_tracing"], capabilities = [5353,4478], id = 5337) 
+void traceRayEXT(accelerationStructureEXT topLevel,
+           uint rayFlags,
+           uint cullMask,
+           uint sbtRecordOffset,
+           uint sbtRecordStride,
+           uint missIndex,
+           vec3 origin,
+           float Tmin,
+           vec3 direction,
+           float Tmax,
+           int payload);
+#endif
+
+#ifdef GL_INTERSECTION_SHADER_EXT
+spirv_instruction (extensions = ["SPV_KHR_ray_tracing"], capabilities = [5353], id = 5334) 
+bool reportIntersectionEXT(float hitT, uint hitKind);
+#endif
+
+#ifdef GL_ANY_HIT_SHADER_EXT
+spirv_instruction (extensions = ["SPV_KHR_ray_tracing"], capabilities = [5353], id = 5335) 
+void ignoreIntersectionEXT();
+
+spirv_instruction (extensions = ["SPV_KHR_ray_tracing"], capabilities = [5353], id = 5336) 
+void terminateRayEXT();
+#endif
+
+#if defined(GL_RAY_GENERATION_SHADER_EXT) || defined(GL_CLOSEST_HIT_SHADER_EXT) || defined(GL_MISS_SHADER_EXT) || defined(GL_CALLABLE_SHADER_EXT)
+spirv_instruction (extensions = ["SPV_KHR_ray_tracing"], capabilities = [5353], id = 5344) 
+void executeCallableEXT(uint sbtRecordIndex, int callable);
+#endif
+#endif
+
+

--- a/extensions/extension_headers/GL_EXT_shader_realtime_clock.glsl
+++ b/extensions/extension_headers/GL_EXT_shader_realtime_clock.glsl
@@ -1,0 +1,17 @@
+#define GL_EXT_shader_realtime_clock 1
+
+uvec2 clockRealtime2x32EXT(void) {
+    spirv_instruction (extensions = ["SPV_KHR_shader_clock"], capabilities = [5055], id = 5056);
+    uvec2 clockRealtime2x32EXT_internal(uint scope);
+    
+    return clockRealtime2x32EXT_internal(1 /*Device scope*/);
+}
+
+#if defined(GL_EXT_shader_explicit_arithmetic_types_int64) || defined(GL_ARB_gpu_shader_int64) || defined(GL_AMD_gpu_shader_int64)
+uint64_t clockRealtimeEXT(void) {
+    spirv_instruction (extensions = ["SPV_KHR_shader_clock"], capabilities = [5055], id = 5056);
+    uint64_t clockRealtimeEXT_internal(uint scope);
+    
+    return clockRealtimeEXT_internal(1 /*Device scope*/);
+}
+#endif


### PR DESCRIPTION
This extension enables spirv opcodes, types, decorations, and storage classes to be directly encoded into GLSL via new qualifiers.

Example "headers" are included which show how the extension can be used. An initial PR for review against glslang will be available for review shortly, and I'll link that from here.