### PR TITLE
Clarify helper behavior to match Vulkan spec

### DIFF
--- a/extensions/khr/GL_KHR_shader_subgroup.txt
+++ b/extensions/khr/GL_KHR_shader_subgroup.txt
@@ -449,9 +449,9 @@ Additions to Chapter 3 of the OpenGL Shading Language Specification
         - In a compute shader, invocations may be inactive within a subgroup
           if the local workgroup size is not a multiple of the subgroup size.
 
-        In fragment shaders, for subgroup operations other than subgroupQuad
-        operations, helper invocations may be treated as inactive even if they
-        would be considered otherwise active.
+        Helper invocations participate in subgroup operations but, for operations
+        other than subgroupQuad operations, they may be treated as inactive even
+        if they would be considered otherwise active.
 
         For each active invocation within a subgroup that reaches the same
         dynamic instance of a subgroup built-in function, all active invocations

--- a/extensions/khr/GL_KHR_shader_subgroup.txt
+++ b/extensions/khr/GL_KHR_shader_subgroup.txt
@@ -449,8 +449,9 @@ Additions to Chapter 3 of the OpenGL Shading Language Specification
         - In a compute shader, invocations may be inactive within a subgroup
           if the local workgroup size is not a multiple of the subgroup size.
 
-        In fragment shaders, helper invocations participate in subgroup
-        operations.
+        In fragment shaders, for subgroup operations other than subgroupQuad
+        operations, helper invocations may be treated as inactive even if they
+        would be considered otherwise active.
 
         For each active invocation within a subgroup that reaches the same
         dynamic instance of a subgroup built-in function, all active invocations


### PR DESCRIPTION
Originally there was a "if they are active then they participate" clause in the Vulkan spec which was confusing, so we updated it to the current language here: https://www.khronos.org/registry/vulkan/specs/1.3/html/chap9.html#shaders-helper-invocations

This change brings the GLSL extension in line with the API spec