### PR TITLE
GL_EXT_control_flow_attributes2

### DIFF
--- a/extensions/ext/GL_EXT_control_flow_attributes2.txt
+++ b/extensions/ext/GL_EXT_control_flow_attributes2.txt
@@ -105,8 +105,8 @@ Add the following control-flow attributes to the table in Section 6.5 Control-Fl
 Add the following before "The *unroll*, *dont_unroll*, *flatten*, and *dont_flatten* attributes are"
 
     /I/ in *min_iterations(I)*/*max_iterations(I)*, /M/ in *iteration_multiple(M)*,
-    and /C/ in *peel_count(C)*/*partial_count(C)* must be a 32-bit positive signed
-    or unsigned non-specialization compile-time constant integral expression, or a
+    and /C/ in *peel_count(C)*/*partial_count(C)* must be a 32-bit signed
+    or unsigned non-specialization compile-time constant integral expression greater than 0, or a
     compile-time error results.
 
 Revision History

--- a/extensions/ext/GL_EXT_control_flow_attributes2.txt
+++ b/extensions/ext/GL_EXT_control_flow_attributes2.txt
@@ -25,7 +25,7 @@ Status
 
 Version
 
-    Last Modified Date: 31-Oct-2023
+    Last Modified Date: 30-Nov-2023
     Revision: 1
 
 Number
@@ -69,6 +69,7 @@ Overview
 
       [[unroll, min_iterations(2)]]  for (int i = 0; i < 8; ++i) { ... }
       [[unroll, min_iterations(2), max_iterations(4)]]  for (int i = 0; i < 8; ++i) { ... }
+      [[unroll, iteration_multiple(4)]]  for (int i = 0; i < 16; ++i) { ... }
       [[unroll, peel_count(3)]]  for (int i = 0; i < 11; ++i) { ... }
       [[unroll, partial_count(2)]]  for (int i = 0; i < 8; ++i) { ... }
 
@@ -119,4 +120,4 @@ Revision History
 
     Rev.    Date         Author          Changes
     ----  -----------    ------------    ----------------------------------------------
-    1     31-Oct-2023    Wooyoung Kim    initial draft
+    1     30-Nov-2023    Wooyoung Kim    initial draft

--- a/extensions/ext/GL_EXT_control_flow_attributes2.txt
+++ b/extensions/ext/GL_EXT_control_flow_attributes2.txt
@@ -25,7 +25,7 @@ Status
 
 Version
 
-    Last Modified Date: 10-Jul-2023
+    Last Modified Date: 31-Oct-2023
     Revision: 1
 
 Number
@@ -119,4 +119,4 @@ Revision History
 
     Rev.    Date         Author          Changes
     ----  -----------    ------------    ----------------------------------------------
-    1     10-Jul-2023    Wooyoung Kim    initial draft
+    1     31-Oct-2023    Wooyoung Kim    initial draft

--- a/extensions/ext/GL_EXT_control_flow_attributes2.txt
+++ b/extensions/ext/GL_EXT_control_flow_attributes2.txt
@@ -1,0 +1,122 @@
+Name
+
+    EXT_control_flow_attributes2
+
+Name Strings
+
+    GL_EXT_control_flow_attributes2
+
+Contact
+
+    Wooyoung Kim (quic_wooykim 'at' quicinc.com), Qualcomm
+
+Contributors
+
+    Ruihao Zhang, Qualcomm
+    Wooyoung Kim, Qualcomm
+
+Notice
+
+    Copyright (c) 2023 Qualcomm, Inc.
+
+Status
+
+    Draft.
+
+Version
+
+    Last Modified Date: 10-Jul-2023
+    Revision: 1
+
+Number
+
+    TBD
+
+Dependencies
+
+    Written against SPIR-V 1.4.
+    Written against GLSL 4.60.7.
+
+    This extension can be applied to OpenGL GLSL versions 1.40
+    (#version 140) and higher.
+
+    This extension can be applied to OpenGL ES ESSL versions 3.10
+    (#version 310) and higher.
+
+    This extension is dependent on an earlier extension GL_EXT_control_flow_attributes.
+
+Overview
+
+    SPIR-V allows a loop to get associated with loop unroll attributes Unroll and DontUnroll.
+
+    SPIR-V 1.4 adds additional loop unroll attributes, MinIterations, MaxIterations,
+    IterationMultiple, PeelCount, and PartialCount to give a consumer
+    hints on how to unroll a loop.
+
+    The GLSL extension "GL_EXT_control_flow_attributes" adds attributes to declare 
+    how loops should be lowered by a consumer (e.g., unroll and dont_unroll).
+    It lacks ways to give a consumer hints to fine-control the unroll behavior.
+
+    The extension adds the attributes missing in the GLSL extension. They are:
+
+      min_iterations
+      max_iterations
+      iteration_multiple
+      peel_count
+      partial_count
+
+    The attributes are expected to be declared with the "unroll" attributes. For example,
+
+      [[unroll, min_iterations(2)]]  for (int i = 0; i < 8; ++i) { ... }
+      [[unroll, min_iterations(2), max_iterations(4)]]  for (int i = 0; i < 8; ++i) { ... }
+      [[unroll, peel_count(3)]]  for (int i = 0; i < 11; ++i) { ... }
+      [[unroll, partial_count(2)]]  for (int i = 0; i < 8; ++i) { ... }
+
+    As with the extension "GL_EXT_control_flow_attributes", combinations that don't make 
+    sense are allowed, but result in only an unknown subset getting applied.
+
+
+Modifications to the OpenGL Shading Language Specification, Version 4.60
+
+    Including the following line in a shader will control the language
+    features described in this extension:
+
+      #extension GL_EXT_control_flow_attributes2 : <behavior>
+
+    Where <behavior> is as specified in section 3.3.
+
+    This new definition is added to the OpenGL Shading Language:
+
+      #define GL_EXT_control_flow_attributes2 1
+
+
+Add the following control-flow attributes to the table in Section 6.5 Control-Flow Attributes
+
+       Attribute              | Relevant on | Intent
+      ------------------------+-------------+------------------------------------
+      *min_iterations(I)*     |    Loop     | the loop executes at least a given number of iterations
+      *max_iterations(I)*     |    Loop     | the loop executes at most a given number of iterations
+      *iteration_multiple(M)* |    Loop     | the loop executes a multiple of a given number of iterations
+      *peel_count(C)*         |    Loop     | the loop be peeled by a given number of loop iterations
+      *partial_count(C)*      |    Loop     | the loop be partially unrolled by a given number of loop iterations
+
+
+Add the following before "The *unroll*, *dont_unroll*, *flatten*, and *dont_flatten* attributes are"
+
+    /I/ in *min_iterations(I)*/*max_iterations(I)*, /M/ in *iteration_multiple(M)*,
+    and /C/ in *peel_count(C)*/*partial_count(C)* must be a 32-bit positive signed
+    or unsigned non-specialization compile-time constant integral expression, or a
+    compile-time error results.
+
+    In addition, /M/ in *iteration_multiple(M)* must be greater than 0.
+
+
+Issues
+
+    1. 
+
+Revision History
+
+    Rev.    Date         Author          Changes
+    ----  -----------    ------------    ----------------------------------------------
+    1     10-Jul-2023    Wooyoung Kim    initial draft

--- a/extensions/ext/GL_EXT_control_flow_attributes2.txt
+++ b/extensions/ext/GL_EXT_control_flow_attributes2.txt
@@ -21,11 +21,11 @@ Notice
 
 Status
 
-    Draft.
+    Final
 
 Version
 
-    Last Modified Date: 30-Nov-2023
+    Last Modified Date: 13-Dec-2023
     Revision: 1
 
 Number
@@ -98,8 +98,8 @@ Add the following control-flow attributes to the table in Section 6.5 Control-Fl
       *min_iterations(I)*     |    Loop     | the loop executes at least a given number of iterations
       *max_iterations(I)*     |    Loop     | the loop executes at most a given number of iterations
       *iteration_multiple(M)* |    Loop     | the loop executes a multiple of a given number of iterations
-      *peel_count(C)*         |    Loop     | the loop be peeled by a given number of loop iterations
-      *partial_count(C)*      |    Loop     | the loop be partially unrolled by a given number of loop iterations
+      *peel_count(C)*         |    Loop     | the loop should be peeled by a given number of loop iterations
+      *partial_count(C)*      |    Loop     | the loop should be partially unrolled by a given number of loop iterations
 
 
 Add the following before "The *unroll*, *dont_unroll*, *flatten*, and *dont_flatten* attributes are"
@@ -109,15 +109,8 @@ Add the following before "The *unroll*, *dont_unroll*, *flatten*, and *dont_flat
     or unsigned non-specialization compile-time constant integral expression, or a
     compile-time error results.
 
-    In addition, /M/ in *iteration_multiple(M)* must be greater than 0.
-
-
-Issues
-
-    1. 
-
 Revision History
 
     Rev.    Date         Author          Changes
     ----  -----------    ------------    ----------------------------------------------
-    1     30-Nov-2023    Wooyoung Kim    initial draft
+    1     13-Dec-2023    Wooyoung Kim    final version


### PR DESCRIPTION
The GLSL extension "GL_EXT_control_flow_attributes" adds attributes to declare how loops should be lowered by a consumer (e.g., unroll and dont_unroll). But not all attributes available in SPIR-V 1.4 are made visible.

The PR is for an extension that adds the attributes missing in the GLSL extension GL_EXT_control_flow_attributes: they are min_iterations, max_iterations, iteration_multiple, peel_count, and partial_count.

Please note that the support for these attributes has already been available in glslangValidator.
