### PR TITLE
Correct spelling of halfBitsToUint16

### DIFF
--- a/extensions/ext/GL_EXT_shader_explicit_arithmetic_types.txt
+++ b/extensions/ext/GL_EXT_shader_explicit_arithmetic_types.txt
@@ -1050,7 +1050,7 @@ Changes to Chapter 8 of the OpenGL Shading Language Specification:
     | genFType ldexp(genFType x, in genI32Type exp)   |  Unchanged                   |
     ----------------------------------------------------------------------------------
     | genI16Type halfBitsToInt16(genF16Type value)    | Returns a signed or unsigned |
-    | genU16Type halfBitsToUInt16(genF16Type value)   | integer value representing   |
+    | genU16Type halfBitsToUint16(genF16Type value)   | integer value representing   |
     | genI32Type floatBitsToInt(genF32Type value)     | the encoding of a floating   |
     | genU32Type floatBitsToUint(genF32Type value)    | point value.  The floating   |
     | genI64Type doubleBitsToInt64(genDType value)    | point value's bit-level      |
@@ -1172,4 +1172,5 @@ Revision History
 
     Rev.    Date         Author               Changes
     ----  -----------    -------------------  --------------------------------
+       2  12-Dec-2023    Graeme Leese         Correct halfBitsToUint16 spelling
        1  3-July-2017    Alexander Galazin    Initial draft


### PR DESCRIPTION
This was incorrectly spelled "UInt" rather than "Uint" in the extension spec.

Fixes #215.