### PR TITLE
Update GL_KHR_vulkan_glsl for Rect textures

### DIFF
--- a/extensions/khr/GL_KHR_vulkan_glsl.txt
+++ b/extensions/khr/GL_KHR_vulkan_glsl.txt
@@ -33,8 +33,8 @@ Status
 
 Version
 
-    Last Modified Date: 16-Mar-2020
-    Revision: 48
+    Last Modified Date: 12-Dec-2023
+    Revision: 49
 
 Number
 
@@ -72,6 +72,7 @@ Overview
         * gl_VertexID and gl_InstanceID
         * aliasing of vertex input components
           (see the Vulkan API specification)
+        * Rectangle textures (sampler*Rect, image*Rect)
 
     The following features are added:
         * push-constant buffers
@@ -366,6 +367,26 @@ Overview
         texture(sampler2D(t, s), ...);
 
     Note, layout() information is omitted above for clarity of this feature.
+
+    Rectangle Textures and Unnormalized Coordinates
+    -----------------------------------------------
+
+    Rectangle textures (gsampler*Rect, gimage2DRect) are not required in Vulkan,
+    which allows sampling any texture using unnormalized coordinates without
+    changing the shader source. For this reason, rectangle textures are removed.
+    In order to comply with Vulkan restrictions on mipmaps with unnormalized
+    coordinates, only texture functions which refer to a specific level of
+    detail may be used.
+
+    Thus, for example, the GLSL code:
+        uniform samplerRect s;
+        ...
+        foo = texture(s, coord);
+
+    should be replaced with:
+        uniform sampler2D s;  // API VkSampler enables unnormalizedCoordinates
+        ...
+        foo = textureLod(s, coord, 0);
         
     Texture Buffers (Uniform Texel Buffers)
     ---------------------------------------
@@ -766,20 +787,19 @@ Changes to Chapter 3 of the OpenGL Shading Language Specification
     Add the following keywords to section 3.6 Keywords:
 
         texture1D        texture2D        texture3D
-        textureCube      texture2DRect    texture1DArray
-        texture2DArray   textureBuffer    texture2DMS
-        texture2DMSArray textureCubeArray
+        textureCube      texture1DArray   texture2DArray
+        textureBuffer    texture2DMS      texture2DMSArray
+        textureCubeArray
 
         itexture1D        itexture2D       itexture3D
-        itextureCube      itexture2DRect   itexture1DArray
-        itexture2DArray   itextureBuffer
-        itexture2DMS      itexture2DMSArray
+        itextureCube      itexture1DArray  itexture2DArray
+        itextureBuffer    itexture2DMS     itexture2DMSArray
         itextureCubeArray
 
         utexture1D        utexture2D        utexture3D
-        utextureCube      utexture2DRect    utexture1DArray
-        utexture2DArray   utextureBuffer    utexture2DMS
-        utexture2DMSArray utextureCubeArray
+        utextureCube      utexture1DArray   utexture2DArray
+        utextureBuffer    utexture2DMS      utexture2DMSArray
+        utextureCubeArray
 
         sampler    samplerShadow
 
@@ -789,6 +809,9 @@ Changes to Chapter 3 of the OpenGL Shading Language Specification
     Move the following keywords in section 3.6 Keywords to the reserved
     section:
 
+        sampler2DRectShadow
+        sampler2DRect    isampler2DRect    usampler2DRect
+        image2DRect      iimage2DRect      uimage2DRect
         atomic_uint
         subroutine
 
@@ -804,7 +827,6 @@ Changes to Chapter 4 of the OpenGL Shading Language Specification
             texture2D
             texture3D
             textureCube
-            texture2DRect
             texture1DArray
             texture2DArray
             textureBuffer
@@ -822,7 +844,6 @@ Changes to Chapter 4 of the OpenGL Shading Language Specification
             itexture2D
             itexture3D
             itextureCube
-            itexture2DRect
             itexture1DArray
             itexture2DArray
             itextureBuffer
@@ -839,7 +860,6 @@ Changes to Chapter 4 of the OpenGL Shading Language Specification
             utexture2D
             utexture3D
             utextureCube
-            utexture2DRect
             utexture1DArray
             utexture2DArray
             utextureBuffer
@@ -1375,7 +1395,7 @@ Changes to Chapter 5 of the OpenGL Shading Language Specification
          * the constructor's first argument must be a texture type
          * the constructor's second argument must be a scalar of type
            *sampler* or *samplerShadow*
-         * the dimensionality (1D, 2D, 3D, Cube, Rect, Buffer, MS, and Array)
+         * the dimensionality (1D, 2D, 3D, Cube, Buffer, MS, and Array)
            of the texture type must match that of the constructed sampler type
            (that is, the suffixes of the type of the first argument and the
            type of the constructor will be spelled the same way)
@@ -1718,6 +1738,8 @@ Revision History
 
     Rev.    Date         Author    Changes
     ----  -----------    -------  --------------------------------------------
+    49    12-Dec-2023    gnl21    Disallow Rect textures, add explanation of using
+                                  unnormalized coordinates with Vulkan.
     48    16-Mar-2020    jbolz    Remove memoryBarrierAtomicCounter()
     47    17-Mar-2019    JohnK    Add vertex-input aliasing to list of removed
                                   features


### PR DESCRIPTION
These are not used in Vulkan because the API does not distinguish these images as different dimensions, allowing mixing-and-matching with samplers that do and do not use unnormalized coordinates.

This update removes the additional Rect handles that were added but could never be used (texture2DRect, etc), explicitly reserves the tokens that already exist in GLSL (sampler2DRect, etc), and adds a brief explanation of how to get this same functionality in Vulkan.

Fixes Vulkan-Docs issue #1582.