### PR TITLE
Fix a typo in GL_EXT_shader_explicit_arithmetic_types.txt 

### DIFF
--- a/extensions/ext/GL_EXT_shader_explicit_arithmetic_types.txt
+++ b/extensions/ext/GL_EXT_shader_explicit_arithmetic_types.txt
@@ -1030,7 +1030,7 @@ Changes to Chapter 8 of the OpenGL Shading Language Specification:
     ------------------------------------------------------------------------------
 
     ---------------------------------------------------------------------------
-    | Function                          | Desciption                          |
+    | Function                          | Description                         |
     ---------------------------------------------------------------------------
     | int64_t packInt2x32(ivec2 v)      | Same as int64_t pack64(i32vec2 v)   |
     | uint64_t packUint2x32(uvec2 v)    | Same as uint64_t pack64(u32vec2 v)  |


### PR DESCRIPTION
Fixes a typo reported in #47.