### PR TITLE
Make `switch_statement_list` and `conditionopt` consistent.

### DIFF
--- a/chapters/grammar.adoc
+++ b/chapters/grammar.adoc
@@ -666,7 +666,7 @@ _switch_statement_ : ::
     _RIGHT_BRACE_
 
 _switch_statement_list_ : ::
-    /* _nothing_ */ +
+    /* _empty_ */ +
     _statement_list_
 
 _case_label_ : ::
@@ -685,8 +685,8 @@ _for_init_statement_ : ::
     _declaration_statement_
 
 _conditionopt_ : ::
-    _condition_ +
-    /* _empty_ */
+    /* _empty_ */ +
+    _condition_
 
 _for_rest_statement_ : ::
     _conditionopt_ _SEMICOLON_ +


### PR DESCRIPTION
Both `switch_statement_list` and `conditionopt` permit an empty entry. In one case we used `_nothing_` and the other `_empty`. As well, the ordering of when the entry was reversed, first in one, second in the other.

This CL makes them consistent by using `_empty_` and listing it first in both grammar productions.