### PR TITLE
Fixup example to use `ivec3`.

### DIFF
--- a/chapters/spirvmappings.adoc
+++ b/chapters/spirvmappings.adoc
@@ -118,7 +118,7 @@ can be made by operations on scalars:
 
     layout(constant_id = 18) const int scX = 1;
     layout(constant_id = 19) const int scZ = 1;
-    const vec3 scVec = vec3(scX, 1, scZ);  // partially specialized vector
+    const ivec3 scVec = ivec3(scX, 1, scZ);  // partially specialized vector
 
 A built-in variable can have a _constant_id_ attached to it:
 

--- a/extensions/khr/GL_KHR_vulkan_glsl.txt
+++ b/extensions/khr/GL_KHR_vulkan_glsl.txt
@@ -179,7 +179,7 @@ Overview
 
         layout(constant_id = 18) const int scX = 1;
         layout(constant_id = 19) const int scZ = 1;
-        const vec3 scVec = vec3(scX, 1, scZ);  // partially specialized vector
+        const ivec3 scVec = ivec3(scX, 1, scZ);  // partially specialized vector
 
     A built-in variable can have a 'constant_id' attached to it:
 


### PR DESCRIPTION
Fix the examples used for specialization constants to remove the implicit type conversion which is not permitted.

Fixes #169