### PR TITLE
Simplify grammar for identifier_list

### DIFF
--- a/chapters/grammar.adoc
+++ b/chapters/grammar.adoc
@@ -290,11 +290,10 @@ _declaration_ : ::
     _type_qualifier_ _IDENTIFIER_ _LEFT_BRACE_ _struct_declaration_list_
     _RIGHT_BRACE_ _IDENTIFIER_ _array_specifier_ _SEMICOLON_ +
     _type_qualifier_ _SEMICOLON_ +
-    _type_qualifier_ _IDENTIFIER_ _SEMICOLON_ +
-    _type_qualifier_ _IDENTIFIER_ _identifier_list_ _SEMICOLON_
+    _type_qualifier_ _identifier_list_ _SEMICOLON_
 
 _identifier_list_ : ::
-    _COMMA_ _IDENTIFIER_ +
+    _IDENTIFIER_ +
     _identifier_list_ _COMMA_ _IDENTIFIER_
 
 _function_prototype_ : ::


### PR DESCRIPTION
An identifier list was defined as one or more identifiers preceded by a comma, so an additional rule was needed for a single identifier. Change the identifier_list to be what would normally be expected, a comma-separated list of one or more identifiers, and remove the additional rule.