### PR TITLE
Simplify grammar for function headers

### DIFF
--- a/chapters/grammar.adoc
+++ b/chapters/grammar.adoc
@@ -298,10 +298,10 @@ _identifier_list_ : ::
     _identifier_list_ _COMMA_ _IDENTIFIER_
 
 _function_prototype_ : ::
-    _fully_specified_type_ _IDENTIFIER_ _LEFT_PAREN_ _parameter_declaration_list_opt_ _RIGHT_PAREN_ +
+    _fully_specified_type_ _IDENTIFIER_ _LEFT_PAREN_ _parameter_declaration_list_opt_ _RIGHT_PAREN_
 
 _parameter_declaration_list_opt_ : ::
-    /* _empty_ */
+    /* _empty_ */ +
     _parameter_declaration_list_
 
 _parameter_declaration_list_ : ::

--- a/chapters/grammar.adoc
+++ b/chapters/grammar.adoc
@@ -298,18 +298,15 @@ _identifier_list_ : ::
     _identifier_list_ _COMMA_ _IDENTIFIER_
 
 _function_prototype_ : ::
-    _function_declarator_ _RIGHT_PAREN_
+    _fully_specified_type_ _IDENTIFIER_ _LEFT_PAREN_ _parameter_declaration_list_opt_ _RIGHT_PAREN_ +
 
-_function_declarator_ : ::
-    _function_header_ +
-    _function_header_with_parameters_
+_parameter_declaration_list_opt_ : ::
+    /* _empty_ */
+    _parameter_declaration_list_
 
-_function_header_with_parameters_ : ::
-    _function_header_ _parameter_declaration_ +
-    _function_header_with_parameters_ _COMMA_ _parameter_declaration_
-
-_function_header_ : ::
-    _fully_specified_type_ _IDENTIFIER_ _LEFT_PAREN_
+_parameter_declaration_list_ : ::
+    _parameter_declaration_
+    _parameter_declaration_list_ _COMMA_ _parameter_declaration_
 
 _parameter_declarator_ : ::
     _type_specifier_ _IDENTIFIER_ +


### PR DESCRIPTION
This makes the grammar rules match how we normally think about function definitions, which makes them easier to understand.