### PR TITLE
Fix markup for textureGrad 1D

### DIFF
--- a/chapters/builtinfunctions.adoc
+++ b/chapters/builtinfunctions.adoc
@@ -1455,7 +1455,7 @@ endif::GLSL[]
       See *textureProj*, *textureLod*, and *textureOffset*.
 |
 ifdef::GLSL[]
-  gvec4 *textureGrad*(gsampler1D _sampler_, _float _P_, float _dPdx_, float _dPdy_) +
+  gvec4 *textureGrad*(gsampler1D _sampler_, float _P_, float _dPdx_, float _dPdy_) +
 endif::GLSL[]
   gvec4 *textureGrad*(gsampler2D _sampler_, vec2 _P_, vec2 _dPdx_, vec2 _dPdy_) +
   gvec4 *textureGrad*(gsampler3D _sampler_, vec3 _P_, vec3 _dPdx_, vec3 _dPdy_) +


### PR DESCRIPTION
There was an extra '_' which was breaking the italic markup.

Fixes internal issue 78. Thanks, @lexaknyazev