### PR TITLE
Avoid implying that normalized texture cannot be signed

### DIFF
--- a/chapters/builtinfunctions.adoc
+++ b/chapters/builtinfunctions.adoc
@@ -988,7 +988,7 @@ Such properties are taken into account as the texture is accessed via the
 built-in functions defined below.
 
 Texture data can be stored by the GL as single-precision floating-point,
-unsigned normalized integer, unsigned integer or signed integer data.
+normalized integer, unsigned integer or signed integer data.
 This is determined by the type of the internal format of the texture.
 
 Texture lookup functions are provided that can return their result as


### PR DESCRIPTION
GL does support signed normalized textures, so change the format list in the GLSL spec to remove the word "unsigned" that implied the signed variants were not valid.

Fixes internal issue 76. Thanks, @lexaknyazev