### PR TITLE
Fix typo on GLSL_EXT_shader_quad_control

### DIFF
--- a/extensions/ext/GLSL_EXT_shader_quad_control.txt
+++ b/extensions/ext/GLSL_EXT_shader_quad_control.txt
@@ -157,22 +157,22 @@ Additions to Chapter 8 of the OpenGL Shading Language Specification
 
     Syntax:
 
-        bool quadAll(bool value);
+        bool subgroupQuadAll(bool value);
 
     Only usable if the extensions GL_KHR_shader_subgroup_vote and
     GL_EXT_shader_quad_control are enabled.
 
-    The function quadAll() returns true if for all active invocations in the
+    The function subgroupQuadAll() returns true if for all active invocations in the
     quad <value> evaluates to true.
 
     Syntax:
 
-        bool quadAny(bool value);
+        bool subgroupQuadAny(bool value);
 
     Only usable if the extensions GL_KHR_shader_subgroup_vote and
     GL_EXT_shader_quad_control are enabled.
 
-    The function quadAny() returns true if for any active invocation in the
+    The function subgroupQuadAny() returns true if for any active invocation in the
     quad its <value> evaluates to true.
 
 Revision History


### PR DESCRIPTION
The `GLSL_EXT_shader_quad_control` extension document is inconsistent in the naming of the quad operations, where both `subgroupQuad*` and `quad*` exists. I believe the correct names are `subgroupQuad*` and not `quad*`. glslang implements `subgroupQuad*`.