### PR TITLE
Move `Description` sections up to the top of sections.

### DIFF
--- a/chapters/builtinfunctions.adoc
+++ b/chapters/builtinfunctions.adoc
@@ -3628,7 +3628,6 @@ Implementations of the {slname} may optionally group multiple shader
 invocations for a single shader stage into a single SIMD invocation group,
 where invocations are assigned to groups in an undefined,
 implementation-dependent manner.
-
 Shader algorithms on such implementations may benefit from being able to
 evaluate a composite of Boolean values over all active invocations in a
 group.


### PR DESCRIPTION
In the few places where a `Description` block was added due to layout the old table formatting, the `Description` is now folded into the header content for that section.