### PR TITLE
Move GL_EXT_optional_input_attachment_index.txt to the right place

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -115,3 +115,4 @@ that do not live in the Khronos registries for OpenGL or OpenGL ES.
 - link:{repo}/nv/GLSL_NV_cooperative_matrix_decode_vector.txt[GLSL_NV_cooperative_matrix_decode_vector]
 - link:{repo}/ext/GL_EXT_ocp_microscaling_types.txt[GL_EXT_ocp_microscaling_types]
 - link:{repo}/ext/GLSL_EXT_cooperative_matrix_maintenance1.txt[GL_EXT_cooperative_matrix_maintenance1]
+- link:{repo}/ext/GL_EXT_optional_input_attachment_index.txt[GL_EXT_optional_input_attachment_index]

--- a/extensions/ext/GL_EXT_optional_input_attachment_index.txt
+++ b/extensions/ext/GL_EXT_optional_input_attachment_index.txt
@@ -16,7 +16,7 @@ Notice
 
 Status
 
-    Draft.
+    Complete
 
 Version
 


### PR DESCRIPTION
This MR also links the extension from the README.adoc file and marks it as complete. Sorry I didn't realize about these details before.

CC @gnl21 